### PR TITLE
bcftbx/IlluminaData: handle "special cases" for bcl2fastq v2 outputs

### DIFF
--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -470,9 +470,9 @@ class IlluminaProject:
                     sample_names.append(sample_name)
             # Create sample objects and populate with appropriate fastqs
             for sample_name in sample_names:
+                sample_dirn = self.dirn
                 if not self.undetermined:
                     # Assume no subdir
-                    sample_dirn = self.dirn
                     fqs = filter(lambda f: IlluminaFastq(f).sample_name
                                  == sample_name,
                                  fastqs)
@@ -492,7 +492,7 @@ class IlluminaProject:
                     except TypeError:
                         # No lane, take all fastqs
                         fqs = [fq for fq in fastqs]
-                self.samples.append(IlluminaSample(self.dirn,
+                self.samples.append(IlluminaSample(sample_dirn,
                                                    fastqs=fqs,
                                                    name=sample_name,
                                                    prefix=''))

--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -284,13 +284,16 @@ class IlluminaData:
         """
         Find projects for a bcl2fastq2-style directory structure
 
+        The output from bcl2fastq2 can be "flat" (i.e. fastqs
+        directly under project dirs) or it can contain "sample"
+        subdirs within project dirs, or a mixture of both.
+
+        In all cases we expect to find a number of 'undetermined'
+        fastqs at the top level of the output (unaligned) directory,
+        and the fastq names will contain the 'S1' sample number
+        construct.
+
         """
-        # The output from bcl2fastq2 is flat
-        # We expect to find a number of 'undetermined' fastqs at
-        # the top level of the output (unaligned) directory,
-        # and one or more projects in subdirectories - each of
-        # which contains all the fastqs for all samples
-        # The strategy is to look for all these things together
         # Look for undetermined fastqs
         undetermined_fqs = filter(lambda f: f.startswith('Undetermined_S0_')
                                   and f.endswith('.fastq.gz'),
@@ -304,16 +307,26 @@ class IlluminaData:
             if not os.path.isdir(dirn):
                 continue
             # Get a list of fastq files
-            fqs = filter(lambda f: f.endswith('.fastq.gz'),
+            fqs = filter(lambda f: f.endswith('.fastq.gz') and
+                         IlluminaFastq(f).sample_number is not None,
                          os.listdir(dirn))
-            if not fqs:
-                continue
-            # Check that fastqs have bcl2fastq2-style names
-            for fq in fqs:
-                if IlluminaFastq(fq).sample_number is None:
-                    break; continue
-            # Looks like a project
-            project_dirs.append(dirn)
+            if fqs:
+                # Looks like a project
+                project_dirs.append(dirn)
+            else:
+                # Look in subdirs
+                subdirs = filter(lambda d:
+                                 os.path.isdir(os.path.join(dirn,d)),
+                                 os.listdir(dirn))
+                if subdirs:
+                    for sd in subdirs:
+                        fqs = filter(lambda f: f.endswith('.fastq.gz') and
+                                     IlluminaFastq(f).sample_number is not None,
+                                     os.listdir(os.path.join(dirn,sd)))
+                        if fqs:
+                            # Looks like a project
+                            project_dirs.append(dirn)
+                            break; continue
         # Raise an exception if no projects found
         if not project_dirs:
             raise IlluminaDataError("No bcl2fastq2-style projects found")
@@ -400,34 +413,52 @@ class IlluminaProject:
                    os.path.isdir(sample_dirn):
                     self.samples.append(IlluminaSample(sample_dirn))
         else:
-            # Examine fastq files to see if naming scheme follows
-            # bcl2fastq v2 convention
-            fastqs = filter(lambda f: f.endswith('.fastq.gz'),
+            # Examine fastq files in top-level dir to see if naming scheme
+            # follows bcl2fastq v2 convention
+            fastqs = filter(lambda f: f.endswith('.fastq.gz') and
+                            IlluminaFastq(f).sample_number is not None,
                             os.listdir(self.dirn))
-            if fastqs and reduce(lambda x,y: x and
-                                 (IlluminaFastq(y).sample_number is not None),
-                                 fastqs,True):
-                # bcl2fastq v2
-                self.project_prefix = ""
+            if fastqs:
+                # Check if this is the top level bcl2fastq v2 output
+                # i.e. does it contain undetermined reads
                 if reduce(lambda x,y: x and
                           os.path.basename(y).startswith('Undetermined_S'),
                           fastqs,True):
                     # These are undetermined fastqs
                     self.undetermined = True
-                    self.name = "Undetermined_indices"
-                else:
-                    # Fastqs from an actual set of samples
-                    self.name = os.path.basename(self.dirn)
-                logging.debug("bcl2fastq 2 project: %s" % self.name)
-            else:
+            if not self.undetermined:
+                # Even if we already have fastqs, we need to check
+                # subdirs for more bcl2fastq v2 style fastqs
+                subdirs = filter(lambda d:
+                                 os.path.isdir(os.path.join(self.dirn,d)),
+                                 os.listdir(self.dirn))
+                for subdir in subdirs:
+                    items = [os.path.join(subdir,x)
+                             for x in
+                             os.listdir(os.path.join(self.dirn,subdir))]
+                    fastqs.extend(filter(lambda f: f.endswith('.fastq.gz') and
+                                         IlluminaFastq(f).sample_number is not None,
+                                         items))
+            if not fastqs:
                 raise IlluminaDataError("Not a project directory: %s " %
                                         self.dirn)
-            # Determine samples from fastq names
+            # bcl2fastq v2 doesn't prefix project or sample dir names
+            self.project_prefix = ""
             self.sample_prefix = ""
+            # Determine project name
+            if not self.undetermined:
+                self.name = os.path.basename(self.dirn)
+            else:
+                self.name = "Undetermined_indices"
+            logging.debug("bcl2fastq 2 project: %s" % self.name)
+            # Determine samples from fastq paths/names
             sample_names = []
             for fq in fastqs:
                 if not self.undetermined:
-                    sample_name = IlluminaFastq(fq).sample_name
+                    try:
+                        sample_name,_ = fq.split(os.sep)
+                    except ValueError:
+                        sample_name = IlluminaFastq(fq).sample_name
                 else:
                     # Use laneX as sample name for undetermined
                     try:
@@ -440,10 +471,19 @@ class IlluminaProject:
             # Create sample objects and populate with appropriate fastqs
             for sample_name in sample_names:
                 if not self.undetermined:
-                    fqs = filter(lambda f:
-                                 IlluminaFastq(f).sample_name == sample_name,
+                    # Assume no subdir
+                    sample_dirn = self.dirn
+                    fqs = filter(lambda f: IlluminaFastq(f).sample_name
+                                 == sample_name,
                                  fastqs)
+                    if not fqs:
+                        # Look for fastqs within a subdir
+                        sample_dirn = os.path.join(self.dirn,sample_name)
+                        fqs = filter(lambda f:
+                                     f.startswith('%s/' % sample_name),
+                                     fastqs)
                 else:
+                    # Handle 'undetermined' data
                     try:
                         fqs = filter(lambda f:
                                      "lane%d" % IlluminaFastq(f).lane_number
@@ -453,7 +493,9 @@ class IlluminaProject:
                         # No lane, take all fastqs
                         fqs = [fq for fq in fastqs]
                 self.samples.append(IlluminaSample(self.dirn,
-                                                   fastqs=fqs))
+                                                   fastqs=fqs,
+                                                   name=sample_name,
+                                                   prefix=''))
         # Raise an exception if no samples found
         if not self.samples:
             raise IlluminaDataError, "No samples found for project %s" % \
@@ -502,7 +544,7 @@ class IlluminaSample:
 
     """
 
-    def __init__(self,dirn,fastqs=None):
+    def __init__(self,dirn,fastqs=None,name=None,prefix='Sample_'):
         """Create and populate a new IlluminaSample object
 
         Arguments:
@@ -510,6 +552,11 @@ class IlluminaSample:
                   the sample
           fastqs: optional, a list of fastq files associated with the
                   sample (expected to be under the directory 'dirn')
+          name: optional, the name of the sample (if not supplied then
+                  will attempt to determine automatically)
+          prefix: optional, explicitly specify the 'prefix' placed in
+                  front of the sample name to generate the matching
+                  directory
 
         """
         self.dirn = dirn
@@ -521,10 +568,14 @@ class IlluminaSample:
                             os.listdir(self.dirn))
         else:
             fastqs = [os.path.basename(f) for f in fastqs]
-        # Set sample name from directory name
-        self.sample_prefix = "Sample_"
-        if os.path.basename(dirn).startswith(self.sample_prefix):
-            # Remove prefix
+        self.sample_prefix = prefix
+        # Set sample name
+        if name is not None:
+            # Supplied explicitly
+            self.name = name
+        elif self.sample_prefix and \
+           os.path.basename(dirn).startswith(self.sample_prefix):
+            # Determine from prefixed directory name
             self.name = os.path.basename(dirn)[len(self.sample_prefix):]
         else:
             # No prefix, obtain name from fastqs

--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -1351,6 +1351,15 @@ class SampleSheet:
           'project_2': [ name1, name2, ...],
           ... }
 
+        or:
+
+        { 'project_1': [ dir/name1, dir/name2, ...],
+          'project_2': [ name1, name2, ...],
+          ... }
+
+        if some samples will be written will be written to
+        subdirectories according to the sample sheet.
+
         """
         projects = {}
         if str(fmt).upper() == 'CASAVA':
@@ -1393,7 +1402,18 @@ class SampleSheet:
             sample_names = []
             for line in self.data:
                 project = line[self._sample_project]
-                sample = line[self._sample_id]
+                if self._sample_name:
+                    name = line[self._sample_name]
+                else:
+                    name = None
+                id_ = line[self._sample_id]
+                prefix = ''
+                if name:
+                    sample = name
+                    if id_ != name:
+                        prefix = '%s/' % id_
+                else:
+                    sample = id_
                 if self.has_lanes:
                     lane_id = "_L%03d" % line['Lane']
                 else:
@@ -1408,7 +1428,7 @@ class SampleSheet:
                     sample_names.append(sample)
                     i = len(sample_names)
                 # Construct fastq basename
-                fqs.append("%s_S%d%s" % (sample,i,lane_id))
+                fqs.append("%s%s_S%d%s" % (prefix,sample,i,lane_id))
                 projects[project] = fqs
         else:
             # Unknown format

--- a/bcftbx/test/test_IlluminaData.py
+++ b/bcftbx/test/test_IlluminaData.py
@@ -1622,6 +1622,28 @@ DADA331XX,6,885-1,PB-885-1,AGTTCC,RNA-seq,,,Peter,AR
 DADA331XX,7,886-1,PB-886-1,ATGTCA,RNA-seq,,,Peter,AR
 DADA331XX,8,PhiX,PhiX control,,Control,,,Peter,Control
 """
+        self.hiseq_sample_sheet_id_and_name_differ_content = """[Header],,,,,,,,,,
+IEMFileVersion,4,,,,,,,,,
+Date,06/03/2014,,,,,,,,,
+Workflow,GenerateFASTQ,,,,,,,,,
+Application,HiSeq FASTQ Only,,,,,,,,,
+Assay,Nextera,,,,,,,,,
+Description,,,,,,,,,,
+Chemistry,Amplicon,,,,,,,,,
+,,,,,,,,,,
+[Reads],,,,,,,,,,
+101,,,,,,,,,,
+101,,,,,,,,,,
+,,,,,,,,,,
+[Settings],,,,,,,,,,
+ReverseComplement,0,,,,,,,,,
+Adapter,CTGTCTCTTATACACATCT,,,,,,,,,
+,,,,,,,,,,
+[Data],,,,,,,,,,
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,PJB1,PJB1-1579,,,N701,CGATGTAT ,N501,TCTTTCCC,PeterBriggs,
+1,PJB2,PJB2-1580,,,N702,TGACCAAT ,N502,TCTTTCCC,PeterBriggs,
+"""
 
     def test_load_hiseq_sample_sheet(self):
         """SampleSheet: load a HiSEQ IEM-format sample sheet
@@ -1904,6 +1926,17 @@ FC0001,1,B8,,CGTACTAG-TAGATCGC,,,,,PJB
         self.assertEqual(output['Project_AR']['Sample_886-1'],
                          ['886-1_ATGTCA_L004',
                           '886-1_ATGTCA_L007'])
+    def test_hiseq_predict_output_bcl2fastq2_id_and_names_differ(self):
+        """SampleSheet: check predicted bcl2fastq2 outputs for HISeq IEM4
+        sample sheet when id and names differ
+
+        """
+        iem = SampleSheet(fp=cStringIO.StringIO(
+            self.hiseq_sample_sheet_id_and_name_differ_content))
+        output = iem.predict_output(fmt='bcl2fastq2')
+        self.assertTrue('PeterBriggs' in output)
+        self.assertEqual(output['PeterBriggs'],
+                         ['PJB1/PJB1-1579_S1_L001','PJB2/PJB2-1580_S2_L001',])
     def test_len(self):
         """SampleSheet: test __len__ built-in
 

--- a/bcftbx/test/test_IlluminaData.py
+++ b/bcftbx/test/test_IlluminaData.py
@@ -1030,6 +1030,11 @@ class BaseTestIlluminaData(unittest.TestCase):
                             mock_illumina_data.fastqs_in_sample(project_name,
                                                                 sample_name)):
             self.assertEqual(fastq,fq)
+        # Check fastqs exist
+        for fastq in illumina_sample.fastq:
+            fq = os.path.join(illumina_sample.dirn,fastq)
+            self.assertTrue(os.path.exists(fq),
+                            "missing fastq: %s" % fq)
         # Check fastq subsets
         r1_fastqs = illumina_sample.fastq_subset(read_number=1)
         r2_fastqs = illumina_sample.fastq_subset(read_number=2)

--- a/bcftbx/test/test_IlluminaData.py
+++ b/bcftbx/test/test_IlluminaData.py
@@ -2773,6 +2773,53 @@ CDE4,CDE4,,,N3,AGTCAA,CDE,""")
         illumina_data = IlluminaData(self.mock_illumina_data.dirn)
         self.assertFalse(verify_run_against_sample_sheet(illumina_data,
                                                         self.sample_sheet))
+
+class TestVerifyRunAgainstBcl2fastq2SampleSheetSpecialCases(unittest.TestCase):
+
+    def setUp(self):
+        # Create a mock Illumina directory
+        self.top_dir = tempfile.mkdtemp()
+        self.mock_illumina_data = MockIlluminaData('test.MockIlluminaData',
+                                                   'bcl2fastq2',
+                                                   paired_end=True,
+                                                   no_lane_splitting=True,
+                                                   top_dir=self.top_dir)
+        self.mock_illumina_data.add_fastq_batch('AB','AB1','AB1_rep1_S1')
+        self.mock_illumina_data.add_fastq_batch('AB','AB2','AB2_rep1_S2')
+        self.mock_illumina_data.add_fastq_batch('CDE','CDE3','CDE3_S3')
+        self.mock_illumina_data.add_fastq_batch('CDE','CDE4','CDE4_S4')
+        self.mock_illumina_data.add_undetermined()
+        self.mock_illumina_data.create()
+        # Sample sheet
+        fno,self.sample_sheet = tempfile.mkstemp()
+        fp = os.fdopen(fno,'w')
+        fp.write("""[Header]
+
+[Reads]
+
+[Settings]
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+AB1,AB1_rep1,,,N0,GCCAAT,AB,
+AB2,AB2_rep1,,,N1,AGTCAA,AB,
+CDE3,CDE3,,,N2,GCCAAT,CDE,
+CDE4,CDE4,,,N3,AGTCAA,CDE,""")
+        fp.close()
+
+    def tearDown(self):
+        # Remove the test directory
+        if self.mock_illumina_data is not None:
+            self.mock_illumina_data.remove()
+        os.rmdir(self.top_dir)
+        os.remove(self.sample_sheet)
+
+    def test_verify_run_against_sample_sheet_ids_and_names_differ(self):
+        """Verify sample sheet against a matching bcl2fastq2 run (ids and names differ)
+        """
+        illumina_data = IlluminaData(self.mock_illumina_data.dirn)
+        self.assertTrue(verify_run_against_sample_sheet(illumina_data,
+                                                        self.sample_sheet))
     
 class TestSummariseProjects(unittest.TestCase):
 


### PR DESCRIPTION
The outputs of `bcl2fastq` v2 vary depending on the contents of the `Sample_ID` and `Sample_Name` fields in the sample sheet:

 - if `Sample_ID` and `Sample_Name` are the same then `Sample_Name` is used as the sample name in the output fastq file and the fastq is written to the "top-level" of the project directory;
- if `Sample_ID` and `Sample_Name` differ then `Sample_Name` is used as the sample name in the output fastq file but the fastq is written to the a subdirectory called `Sample_ID` under the "top-level" of the project directory;
- if `Sample_Name` is empty then `Sample_ID`  is used as the sample name in the output fastq file and the fastq is written to the "top-level" of the project directory;

Currently only the first case is handled by the code in `bcftbx/IlluminaData.py` (and there is some ambigiuity over the use of `Sample_ID` and `Sample_Name`). This PR attempts to address this so that all the above cases are handled, specifically:

- The `IlluminaData`, `IlluminaProject` and `IlluminaSample` classes are able to deal with all three cases, and
- The `SampleSheet.predict_outputs` method correctly predicts the outputs for all three cases, and
- The `verify_run_against_sample_sheet` function correctly matches the outputs in each case.