### PR TITLE
Enable functionality to output XLSX files from simple_xls.py

### DIFF
--- a/ChIP-seq/make_macs2_xls.py
+++ b/ChIP-seq/make_macs2_xls.py
@@ -417,6 +417,10 @@ def xls_for_macs2(macs_xls,row_limit=None,cell_char_limit=None):
             logging.warning("No legend description found for column '%s'" % name)
             legends.append_row(data=(name,name.title()))
 
+    # "Freeze" top line of each 'data' sheet
+    for data in data_sheets:
+        data.freeze_panes = 'A2'
+
     # Return spreadsheet object
     return xls
 

--- a/ChIP-seq/make_macs2_xls.py
+++ b/ChIP-seq/make_macs2_xls.py
@@ -278,13 +278,15 @@ class MacsXLS:
 # Functions
 #######################################################################
 
-def xls_for_macs2(macs_xls,row_limit=None):
+def xls_for_macs2(macs_xls,row_limit=None,cell_char_limit=None):
     """Create and return XLS workbook object for MACS2 output
 
     Arguments:
       macs_xls: populated MacsXLS object (must be from MACS2)
       row_limit: explicitly specify maximum number of rows per
         output sheet
+      cell_character_limit: explicitly specify maximum number
+        of characters per cell
 
     Returns:
       simple_xls.XLSWorkBook
@@ -303,6 +305,13 @@ def xls_for_macs2(macs_xls,row_limit=None):
         row_limit = simple_xls.Limits.MAX_NUMBER_ROWS_PER_WORKSHEET
     if len(macs_xls.data) > row_limit:
         logging.warning("Data will be split over multiple worksheets on output")
+
+    # Maximum number of characters per cell
+    if cell_char_limit is None:
+        cell_char_limit = simple_xls.Limits.MAX_LEN_WORKSHEET_CELL_VALUE
+
+    # Maximum length of a data sheet title
+    sheet_title_limit = simple_xls.Limits.MAX_LEN_WORKSHEET_TITLE
 
     # Legend descriptions for all possible columns
     legends_text = { 'order': "Sorting order FE",
@@ -340,7 +349,7 @@ def xls_for_macs2(macs_xls,row_limit=None):
         if data.last_row == row_limit:
             sheet_number += 1
             name = "data%d" % sheet_number
-            title = "%s(%d)" % (macs_xls.name[:simple_xls.Limits.MAX_LEN_WORKSHEET_TITLE-4],
+            title = "%s(%d)" % (macs_xls.name[:sheet_title_limit-4],
                                 sheet_number)
             print "Making additional data sheet '%s'" % title
             data = xls.add_work_sheet(name,title)
@@ -388,14 +397,13 @@ def xls_for_macs2(macs_xls,row_limit=None):
 
     # Check for and address too-long "Command line" cell i.e. if it
     # exceeds maximum size for a spreadsheet cell
-    char_limit = simple_xls.Limits.MAX_LEN_WORKSHEET_CELL_VALUE
     for row in range(1,notes.last_row+1):
         if notes['A'][row].startswith("# Command line:"):
             command_line = notes['A'][row]
-            if len(command_line) > char_limit:
+            if len(command_line) > cell_char_limit:
                 # Chop up command line string over multiple cells
                 logging.warning("Splitting command line over multiple cells")
-                row_data = chunk(command_line,char_limit,delimiter=' ')
+                row_data = chunk(command_line,cell_char_limit,delimiter=' ')
                 notes.write_row(row,data=row_data)
         
     # Build the 'legends' sheet based on content of 'data'
@@ -1010,10 +1018,14 @@ def main(macs_file,xls_out,xls_format="xlsx"):
     print "Generating XLS file"
     if xls_format == "xlsx":
         xls_max_rows = simple_xls.XLSXLimits.MAX_NUMBER_ROWS_PER_WORKSHEET
+        xls_cell_width = simple_xls.XLSXLimits.MAX_LEN_WORKSHEET_CELL_VALUE
     elif xls_format == "xls":
         xls_max_rows = simple_xls.XLSLimits.MAX_NUMBER_ROWS_PER_WORKSHEET
+        xls_cell_width = simple_xls.XLSLimits.MAX_LEN_WORKSHEET_CELL_VALUE
     try:
-        xls = xls_for_macs2(macs_xls)
+        xls = xls_for_macs2(macs_xls,
+                            row_limit=xls_max_rows,
+                            cell_char_limit=xls_cell_width)
     except Exception,ex:
         logging.error("failed to convert to XLS: %s" % ex)
         sys.exit(1)

--- a/ChIP-seq/make_macs2_xls.py
+++ b/ChIP-seq/make_macs2_xls.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
-#     make_macs2_xls.py: Convert MACS output file to XLS spreadsheet
-#     Copyright (C) University of Manchester 2013-2014 Peter Briggs, Ian Donaldson
+#     make_macs2_xls.py: Convert MACS output file to XLS(X) spreadsheet
+#     Copyright (C) University of Manchester 2013-2016 Peter Briggs, Ian Donaldson
 #
 ########################################################################
 #
@@ -11,9 +11,9 @@
 
 """make_macs2_xls.py
 
-Convert MACS output file to XLS spreadsheet
+Convert MACS output file to XLS(X) spreadsheet
 
-Given tab-delimited output from MACS, creates an XLS spreadsheet with
+Given tab-delimited output from MACS, creates an Excel spreadsheet with
 3 sheets: one containing the tabulated data plus extra columns derived
 from that data (e.g. summit+/-100bps); one containing the header
 information from the input; and one describing what each of the columns
@@ -48,7 +48,7 @@ import profile
 # Module metadata
 #######################################################################
 
-__version__ = '0.3.2'
+__version__ = '0.4.0'
 
 #######################################################################
 # Class definitions
@@ -976,7 +976,7 @@ class TestChunkFunction(unittest.TestCase):
 # Main program
 #######################################################################
 
-def main(macs_file,xls_out):
+def main(macs_file,xls_out,xls_format="xlsx"):
     """Driver function
 
     Wraps core functionality of program to facilitate
@@ -984,9 +984,14 @@ def main(macs_file,xls_out):
     
     Arguments:
       macs_file: output .xls file from MACS peak caller
-      xls_out: name to write output XL spreadsheet file to
+      xls_out: name to write output XLS spreadsheet file to
+      xls_format: optional, specify the XLS output format
+        (either 'xls' or 'xlsx'; default is 'xlsx')
     
     """
+    # Check requested XLS format
+    if xls_format not in ('xls','xlsx'):
+        raise Exception("Unrecognised XLS format: %s" % xls_format)
 
     # Load the data from the file
     print "Reading data...",
@@ -1003,41 +1008,58 @@ def main(macs_file,xls_out):
 
     # Create XLS file
     print "Generating XLS file"
+    if xls_format == "xlsx":
+        xls_max_rows = simple_xls.XLSXLimits.MAX_NUMBER_ROWS_PER_WORKSHEET
+    elif xls_format == "xls":
+        xls_max_rows = simple_xls.XLSLimits.MAX_NUMBER_ROWS_PER_WORKSHEET
     try:
         xls = xls_for_macs2(macs_xls)
     except Exception,ex:
         logging.error("failed to convert to XLS: %s" % ex)
         sys.exit(1)
-    xls.save_as_xls(xls_out)
+    if xls_format == "xlsx":
+        xls.save_as_xlsx(xls_out)
+    elif xls_format == "xls":
+        xls.save_as_xls(xls_out)
     print "Finished"
 
 if __name__ == "__main__":
     # Process command line
-    p = optparse.OptionParser(usage="%prog <MACS2_OUTPUT> [ <XLS_OUT> ]",
+    p = optparse.OptionParser(usage="%prog OPTIONS MACS2_XLS [ XLS_OUT ]",
                               version=__version__,
                               description=
-                              "Create an XLS spreadsheet from the output of version 2.0.10 "
-                              "of the MACS peak caller. <MACS2_OUTPUT> is the output '.xls' "
-                              "file from MACS2; if supplied then <XLS_OUT> is the name to use "
-                              "for the output file, otherwise it will be called "
-                              "'XLS_<MACS2_OUTPUT>.xls'.")
+                              "Create an XLS(X) spreadsheet from the output "
+                              "of the MACS2 peak caller. MACS2_XLS is the "
+                              "output '.xls' file from MACS2; if supplied "
+                              "then XLS_OUT is the name to use for the output "
+                              "file (otherwise it will be called "
+                              "'XLS_<MACS2_XLS>.xls(x)'.")
+    p.add_option("-f","--format",
+                 action="store",dest="xls_format",default="xlsx",
+                 help="specify the output Excel spreadsheet format; must be "
+                 "one of 'xlsx' or 'xls' (default is 'xlsx')")
     options,args = p.parse_args()
     # Get input file name
     if len(args) < 1 or len(args) > 2:
         p.error("Wrong number of arguments")
     macs_in = args[0]
+    # Get output Excel format
+    xls_format = str(options.xls_format).lower()
+    if xls_format not in ('xls','xlsx'):
+        p.error("Unrecognised Excel format: %s" % xls_format)
     # Report version
     print "%s %s" % (os.path.basename(sys.argv[0]),__version__)
     # Build output file name: if not explicitly supplied on the command
-    # line then use "XLS_<input_name>.xls"
+    # line then use "XLS_<input_name>.<xls_format>"
     if len(args) == 2:
         xls_out = args[1]
     else:
         # MACS output file might already have an .xls extension
         # but we'll add an explicit .xls extension
-        xls_out = "XLS_"+os.path.splitext(os.path.basename(macs_in))[0]+".xls"
+        xls_out = "XLS_"+os.path.splitext(os.path.basename(macs_in))[0]+\
+                  "."+xls_format
     print "Input file: %s" % macs_in
     print "Output XLS: %s" % xls_out
     ##profile.run("main(macs_in,xls_out)")
-    main(macs_in,xls_out)
+    main(macs_in,xls_out,xls_format=xls_format)
 

--- a/bcftbx/Spreadsheet.py
+++ b/bcftbx/Spreadsheet.py
@@ -321,6 +321,9 @@ class Worksheet:
         self.styles = Styles()
         # Maximum column widths
         self.max_col_width = []
+        # Freeze panes
+        self.freeze_row = 0
+        self.freeze_col = 0
 
     def addTabData(self,rows):
         """Write a list of tab-delimited data rows to the sheet.
@@ -483,6 +486,16 @@ class Worksheet:
             # Column name not found
             raise IndexError, "Column '%s' not found" % name
 
+    def freezePanes(self,row=None,column=None):
+        """Split panes and mark as frozen
+
+        'row' and 'column' are integer indices specifying the
+        cell which defines the pane to be marked as frozen
+
+        """
+        self.freeze_row = int(row)
+        self.freeze_col = int(column)
+
     def column_id_from_index(self,i):
         """Get XLS column id from index of column
 
@@ -606,6 +619,11 @@ class Worksheet:
                 except ValueError, ex:
                     logging.error("couldn't write item to sheet '%s' (row %d col %d)" %
                                   (self.title,self.current_row+1,cindex+1))
+        # Freeze panes
+        self.worksheet.set_horz_split_pos(self.freeze_row)
+        self.worksheet.set_vert_split_pos(self.freeze_col)
+        if self.freeze_row or self.freeze_col:
+            self.worksheet.set_panes_frozen(True)
         # Update/reset the sheet properties etc
         self.data = []
         self.is_new = False

--- a/bcftbx/simple_xls.py
+++ b/bcftbx/simple_xls.py
@@ -135,10 +135,16 @@ class NumberFormats:
     PERCENTAGE=1
 
 # Spreadsheet limits
+# NB these are for XLS not XLSX
+# In XLSX file the limits are:
+# max rows=1048576
+# max cols=16384
+# Number of characters per cell may be 1024
 class Limits:
     MAX_LEN_WORKSHEET_TITLE = 31 # Max worksheet title length
     MAX_LEN_WORKSHEET_CELL_VALUE = 250 # Maximum no. of characters in cell
     MAX_NUMBER_ROWS_PER_WORKSHEET = 65536 # Max number of rows per worksheet
+    MAX_NUMBER_COLS_PER_WORKSHEET = 256 # Max nuber of columns per worksheet
 
 #######################################################################
 # Class definitions

--- a/bcftbx/simple_xls.py
+++ b/bcftbx/simple_xls.py
@@ -135,16 +135,27 @@ class NumberFormats:
     PERCENTAGE=1
 
 # Spreadsheet limits
-# NB these are for XLS not XLSX
-# In XLSX file the limits are:
-# max rows=1048576
-# max cols=16384
-# Number of characters per cell may be 1024
-class Limits:
+class XLSLimits:
+    """
+    Limits for XLS files
+    """
     MAX_LEN_WORKSHEET_TITLE = 31 # Max worksheet title length
     MAX_LEN_WORKSHEET_CELL_VALUE = 250 # Maximum no. of characters in cell
     MAX_NUMBER_ROWS_PER_WORKSHEET = 65536 # Max number of rows per worksheet
     MAX_NUMBER_COLS_PER_WORKSHEET = 256 # Max nuber of columns per worksheet
+
+class XLSXLimits:
+    """
+    Limits for XLSX files
+    """
+    MAX_LEN_WORKSHEET_CELL_VALUE = 1024 # Maximum no. of characters in cell
+    MAX_NUMBER_ROWS_PER_WORKSHEET = 1048576 # Max number of rows per worksheet
+    MAX_NUMBER_COLS_PER_WORKSHEET = 16384 # Max nuber of columns per worksheet
+
+class Limits(XLSLimits):
+    """
+    Limits for XLS files (kept for backwards compatibility)
+    """
 
 #######################################################################
 # Class definitions

--- a/bcftbx/simple_xls.py
+++ b/bcftbx/simple_xls.py
@@ -1039,6 +1039,12 @@ class XLSStyle:
     centre: whether text is centred in the cell (boolean)
     shrink_to_fit: whether to shrink cell to fit the contents.
 
+    The 'name' property can be used to generate a name for the style
+    based on the attributes that have been set, for example:
+
+    >>> XLSStyle(bold=true).name
+    ... '__bold__'
+
     """
     def __init__(self,bold=False,color=None,bgcolor=None,wrap=False,
                  border=None,number_format=None,font_size=None,centre=False,
@@ -1057,6 +1063,47 @@ class XLSStyle:
         self.font_size = font_size
         self.centre = centre
         self.shrink_to_fit = shrink_to_fit
+
+    def __nonzero__(self):
+        return \
+            (self.bold) or \
+            (self.color is not None) or \
+            (self.bgcolor is not None) or \
+            (self.wrap) or \
+            (self.border is not None) or \
+            (self.number_format is not None) or \
+            (self.font_size is not None) or \
+            (self.centre) or \
+            (self.shrink_to_fit)
+
+    @property
+    def name(self):
+        """Return a name based on the attributes
+        """
+        name = []
+        if self.bold:
+            name.append('bold')
+        if self.color is not None:
+            name.append('color=%s' % self.color)
+        if self.bgcolor is not None:
+            name.append('bgcolor=%s' % self.bgcolor)
+        if self.wrap:
+            name.append('wrap')
+        if self.border is not None:
+            name.append('border=%s' % self.border)
+        if self.number_format is not None:
+            name.append('number_format=%s' % self.number_format)
+        if self.font_size is not None:
+            name.append('font_size=%s' % self.font_size)
+        if self.centre:
+            name.append('centre')
+        if self.shrink_to_fit:
+            name.append('shrink_to_fit')
+        name = '__'.join(name)
+        if name:
+            return '__%s__' % name
+        else:
+            return ''
 
     def style(self,item):
         """Wrap 'item' with <style...>...</style> tags

--- a/bcftbx/simple_xls.py
+++ b/bcftbx/simple_xls.py
@@ -214,6 +214,11 @@ class XLSWorkBook:
             worksheet = self.worksheet[name]
             ws = xls.addSheet(worksheet.title)
             ws.addText(worksheet.render_as_text(include_styles=True))
+            if worksheet.freeze_panes is not None:
+                col = column_index_to_integer(
+                    CellIndex(worksheet.freeze_panes).column)
+                row = CellIndex(worksheet.freeze_panes).row - 1
+                ws.freezePanes(column=col,row=row)
         xls.save(filen)
 
     def save_as_xlsx(self,filen):
@@ -288,6 +293,9 @@ class XLSWorkBook:
                 # Set the column width
                 icol = column_index_to_integer(col)
                 ws.set_column(icol,icol,max_width*1.2)
+            # Handle freeze panes
+            if worksheet.freeze_panes is not None:
+                ws.freeze_panes(worksheet.freeze_panes)
         xlsx.close()
 
 class XLSWorkSheet:
@@ -367,6 +375,7 @@ class XLSWorkSheet:
         self.styles = {}
         self.rows = []
         self.columns = []
+        self.freeze_panes = None
 
     def __setitem__(self,idx,value):
         """Implement 'x[idx] = value'
@@ -1649,6 +1658,17 @@ if __name__ == "__main__":
     ws.set_style(XLSStyle(color='red'),'A10')
     ws['A11'] = "White on green"
     ws.set_style(XLSStyle(bold=True,color='white',bgcolor='green'),'A11')
+    ws['A12'] = "Black on gray"
+    ws.set_style(XLSStyle(bold=True,color='black',bgcolor='gray25'),'A12')
+    # Freeze panes
+    ws = wb.add_work_sheet('freeze','Freeze')
+    ws.append_row(data=('X','Y','Z'),
+                  style=XLSStyle(color='white',
+                                 bgcolor='green',
+                                 bold=True))
+    for i in xrange(100):
+        ws.append_row(data=(i,i*2,'=A?+B?'))
+    ws.freeze_panes = 'A2'
     # Save out to XLS(X) files
     wb.save_as_xls('test.xls')
     wb.save_as_xlsx('test.xlsx')

--- a/bcftbx/test/test_simple_xls.py
+++ b/bcftbx/test/test_simple_xls.py
@@ -461,6 +461,34 @@ class TestXLSStyle(unittest.TestCase):
         self.assertEqual(XLSStyle(
             number_format=NumberFormats.PERCENTAGE).excel_number_format,
                          "0.0%")
+    def test_nonzero(self):
+        self.assertFalse(XLSStyle())
+        self.assertTrue(XLSStyle(bold=True))
+        self.assertTrue(XLSStyle(wrap=True))
+        self.assertTrue(XLSStyle(color='red'))
+        self.assertTrue(XLSStyle(bgcolor='blue'))
+        self.assertTrue(XLSStyle(number_format=NumberFormats.PERCENTAGE))
+        self.assertTrue(XLSStyle(border='thick'))
+        self.assertTrue(XLSStyle(font_size=14))
+        self.assertTrue(XLSStyle(centre=True))
+        self.assertTrue(XLSStyle(shrink_to_fit=True))
+        self.assertTrue(XLSStyle(bold=True,bgcolor='green'))
+    def test_name(self):
+        self.assertEqual(XLSStyle.name,'')
+        self.assertEqual(XLSStyle(bold=True),'__bold__')
+        self.assertEqual(XLSStyle(color=True),'__bold__')
+        self.assertEqual(XLSStyle(color='red'),'__color=red__')
+        self.assertEqual(XLSStyle(bgcolor='blue'),'__bgcolor=blue__')
+        self.assertEqual(XLSStyle(number_format=NumberFormats.PERCENTAGE),
+                         '__number_format=1__')
+        self.assertEqual(XLSStyle(border='thick'),'__border=thick__')
+        self.assertEqual(XLSStyle(font_size=14),'__font_size=14__')
+        self.assertEqual(XLSStyle(centre=True),'__centre__')
+        self.assertEqual(XLSStyle(shrink_to_fit=True),'__shrink_to_fit__')
+        self.assertEqual(XLSStyle(bold=True,bgcolor='green'),
+                         '__bold__bgcolor=green__')
+        self.assertEqual(XLSStyle(bold=True,font_size=14,centre=True),
+                         '__bold__font_size=14__centre__')
 
 class TestCmpColumnIndices(unittest.TestCase):
     """

--- a/bcftbx/test/test_simple_xls.py
+++ b/bcftbx/test/test_simple_xls.py
@@ -4,6 +4,67 @@
 from bcftbx.simple_xls import *
 import unittest
 import itertools
+import os
+import tempfile
+
+class TestXLSWorkBook(unittest.TestCase):
+    """
+    """
+    def setUp(self):
+        # Store temp area, if needed
+        self.wd = None
+    def tearDown(self):
+        # Remove working area, if defined
+        if self.wd is not None and os.path.isdir(self.wd):
+            try:
+                os.rmdir(self.wd)
+            except Exception:
+                pass
+    def _add_test_worksheet(self,ws):
+        # Add content to example worksheet
+        ws['A1'] = "Arbitrary text"
+        # Formula
+        ws['A3'] = "Formula example:"
+        ws['A5'] = 2
+        ws['B5'] = 5
+        ws['A6'] = "Sum"
+        ws['B6'] = "=A5+B5"
+        # Set styles on formula
+        ws.set_style(XLSStyle(bold=True),'A6')
+        ws.set_style(XLSStyle(bold=True),'B6')
+        # More style examples
+        ws['A9'] = "Bold"
+        ws.set_style(XLSStyle(bold=True),'A9')
+        ws['A10'] = "Red"
+        ws.set_style(XLSStyle(color='red'),'A10')
+        ws['A11'] = "White on green"
+        ws.set_style(XLSStyle(bold=True,color='white',bgcolor='green'),'A11')
+    def test_work_book_add_worksheet(self):
+        wb = XLSWorkBook("Test")
+        ws1 = wb.add_work_sheet('wsheet1','Test #1')
+        self.assertEqual(ws1,wb.worksheet['wsheet1'])
+    def test_work_book_save_as_xls(self):
+        wb = XLSWorkBook("Test")
+        self.wd = tempfile.mkdtemp()
+        # Add content
+        ws = wb.add_work_sheet('test','Test')
+        self._add_test_worksheet(ws)
+        # Save out to XLS(X) files
+        xls_out = os.path.join(self.wd,'test.xls')
+        wb.save_as_xls(xls_out)
+        # Check file exists
+        self.assertTrue(os.path.isfile(xls_out))
+    def test_work_book_save_as_xlsx(self):
+        wb = XLSWorkBook("Test")
+        self.wd = tempfile.mkdtemp()
+        # Add content
+        ws = wb.add_work_sheet('test','Test')
+        self._add_test_worksheet(ws)
+        # Save out to XLS(X) files
+        xlsx_out = os.path.join(self.wd,'test.xlsx')
+        wb.save_as_xlsx(xlsx_out)
+        # Check file exists
+        self.assertTrue(os.path.isfile(xlsx_out))
 
 class TestXLSWorkSheet(unittest.TestCase):
     """

--- a/bcftbx/test/test_simple_xls.py
+++ b/bcftbx/test/test_simple_xls.py
@@ -474,20 +474,19 @@ class TestXLSStyle(unittest.TestCase):
         self.assertTrue(XLSStyle(shrink_to_fit=True))
         self.assertTrue(XLSStyle(bold=True,bgcolor='green'))
     def test_name(self):
-        self.assertEqual(XLSStyle.name,'')
-        self.assertEqual(XLSStyle(bold=True),'__bold__')
-        self.assertEqual(XLSStyle(color=True),'__bold__')
-        self.assertEqual(XLSStyle(color='red'),'__color=red__')
-        self.assertEqual(XLSStyle(bgcolor='blue'),'__bgcolor=blue__')
-        self.assertEqual(XLSStyle(number_format=NumberFormats.PERCENTAGE),
+        self.assertEqual(XLSStyle().name,'')
+        self.assertEqual(XLSStyle(bold=True).name,'__bold__')
+        self.assertEqual(XLSStyle(color='red').name,'__color=red__')
+        self.assertEqual(XLSStyle(bgcolor='blue').name,'__bgcolor=blue__')
+        self.assertEqual(XLSStyle(number_format=NumberFormats.PERCENTAGE).name,
                          '__number_format=1__')
-        self.assertEqual(XLSStyle(border='thick'),'__border=thick__')
-        self.assertEqual(XLSStyle(font_size=14),'__font_size=14__')
-        self.assertEqual(XLSStyle(centre=True),'__centre__')
-        self.assertEqual(XLSStyle(shrink_to_fit=True),'__shrink_to_fit__')
-        self.assertEqual(XLSStyle(bold=True,bgcolor='green'),
+        self.assertEqual(XLSStyle(border='thick').name,'__border=thick__')
+        self.assertEqual(XLSStyle(font_size=14).name,'__font_size=14__')
+        self.assertEqual(XLSStyle(centre=True).name,'__centre__')
+        self.assertEqual(XLSStyle(shrink_to_fit=True).name,'__shrink_to_fit__')
+        self.assertEqual(XLSStyle(bold=True,bgcolor='green').name,
                          '__bold__bgcolor=green__')
-        self.assertEqual(XLSStyle(bold=True,font_size=14,centre=True),
+        self.assertEqual(XLSStyle(bold=True,font_size=14,centre=True).name,
                          '__bold__font_size=14__centre__')
 
 class TestCmpColumnIndices(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ setup(name = "genomics-bcftbx",
       # Pull in dependencies
       install_requires = ['xlwt >= 0.7.2',
                           'xlrd >= 0.7.1',
-                          'xlutils >= 1.4.1'],
+                          'xlutils >= 1.4.1',
+                          'xlsxwriter >= 0.8.4',],
       # Enable 'python setup.py test'
       test_suite='nose.collector',
       tests_require=['nose'],


### PR DESCRIPTION
This PR adds a new function `save_as_xlsx` to the `XLSWorkBook` class of `bcftbx/simple_xls.py`, which enables the workbook to be saved in XLSX format.

This functionality co-exists with the `save_as_xls` function, so XLS output continues to be available.