### PR TITLE
Fix IlluminaData classes to handle non canonical Fastq names

### DIFF
--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -1468,17 +1468,7 @@ class SampleSheet:
                 if sample not in samples:
                     samples[sample] = []
                 # Index sequence
-                try:
-                    # Try dual-indexed IEM4 format
-                    indx = "%s-%s" %(line['index'].strip(),
-                                     line['index2'].strip())
-                except KeyError:
-                    # Try single indexed IEM4 (no index2)
-                    try:
-                        indx = line['index'].strip()
-                    except KeyError:
-                        # Try CASAVA format
-                        indx = line['Index'].strip()
+                indx = samplesheet_index_sequence(line)
                 if not indx:
                     indx = "NoIndex"
                 # Lane
@@ -1585,16 +1575,9 @@ class IEMSampleSheet(SampleSheet):
                 # No lane column (e.g. MiSEQ)
                 lane = 1
             # Set the index tag (if any)
-            try:
-                index_tag = "%s-%s" % (line['index'].strip(),
-                                       line['index2'].strip())
-            except KeyError:
-                # Assume not dual-indexed (no index2)
-                try:
-                    index_tag = line['index'].strip()
-                except KeyError:
-                    # No index
-                    index_tag = ''
+            index_tag = samplesheet_index_sequence(line)
+            if not index_tag:
+                index_tag = ''
             sample_sheet_line['FCID'] = FCID
             sample_sheet_line['Lane'] = lane
             sample_sheet_line['Index'] = index_tag
@@ -2212,6 +2195,9 @@ def samplesheet_index_sequence(line):
 
     Arguments:
       line (TabDataLine): line from a SampleSheet instance
+
+    Returns:
+      String: barcode sequence, or 'None' if not defined.
 
     """
     # Index sequence

--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -2205,3 +2205,41 @@ def fix_bases_mask(bases_mask,barcode_sequence):
         reads.append(new_read)
     # Assemble and return updated index tags
     return ','.join(reads)
+
+def samplesheet_index_sequence(line):
+    """
+    Return the index sequence for a sample sheet line
+
+    Arguments:
+      line (TabDataLine): line from a SampleSheet instance
+
+    """
+    # Index sequence
+    try:
+        # Try dual-indexed IEM4 format
+        return "%s-%s" % (line['index'].strip(),
+                          line['index2'].strip())
+    except KeyError:
+        pass
+    # Try single indexed IEM4 (no index2)
+    try:
+        return line['index'].strip()
+    except KeyError:
+        pass
+    # Try CASAVA format
+    indx = line['Index'].strip()
+    if not indx:
+        indx = None
+    return indx
+
+def normalise_barcode(seq):
+    """
+    Return normalised version of barcode sequence
+
+    This standardises the sequence so that:
+
+    - all bases are uppercase
+    - dual index barcodes have '-' and '+' removed
+
+    """
+    return str(seq).upper().replace('-','').replace('+','')

--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -1734,9 +1734,18 @@ class IlluminaFastq:
         fields = fastq_base.split('_')
         nfields = len(fields)
         # Set number: zero-padded 3 digit integer '001'
-        self.set_number = int(fields[-1])
+        try:
+            self.set_number = int(fields[-1])
+        except ValueError:
+            raise IlluminaDataError(
+                "%s: not a canonical Illumina Fastq name" % fastq_base)
         # Read number: single integer digit 'R1'
-        self.read_number = int(fields[-2][1])
+        if fields[-2].startswith('R'):
+            try:
+                self.read_number = int(fields[-2][1])
+            except ValueError:
+                raise IlluminaDataError(
+                    "%s: not a canonical Illumina Fastq name" % fastq_base)
         # Lane number: zero-padded 3 digit integer 'L001'
         if fields[-3].startswith('L') and fields[-3][1:].isdigit():
             self.lane_number = int(fields[-3][1:])

--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -2227,7 +2227,10 @@ def samplesheet_index_sequence(line):
     except KeyError:
         pass
     # Try CASAVA format
-    indx = line['Index'].strip()
+    try:
+        indx = line['Index'].strip()
+    except KeyError:
+        indx = ''
     if not indx:
         indx = None
     return indx

--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -695,7 +695,7 @@ class IlluminaSample:
         for fastq in self.fastq:
             fq = IlluminaFastq(fastq)
             if fq.read_number is None:
-                raise IlluminaDataException, \
+                raise IlluminaDataError, \
                     "Unable to determine read number for %s" % fastq
             if fq.read_number == read_number:
                 if full_path:

--- a/bcftbx/test/test_IlluminaData.py
+++ b/bcftbx/test/test_IlluminaData.py
@@ -565,6 +565,18 @@ class TestIlluminaDataForBcl2fastq2SpecialCases(BaseTestIlluminaData):
                               'fastqs',fq),'w').write('')
         return os.path.join(self.top_dir,'test.MockIlluminaData')
 
+    def makeNonIlluminaDataDirectoryWithNonCanonicalFastqs(self):
+        # Create a non-bcl2fastq directory which contains
+        # Fastq files with non-canonical-style names
+        os.mkdir(os.path.join(self.top_dir,'test.MockIlluminaData'))
+        os.mkdir(os.path.join(self.top_dir,'test.MockIlluminaData','fastqs'))
+        for fq in ('PB04_S4_R1_unpaired.fastq.gz',
+                   'PB04_trimmoPE_bowtie2_notHg38.1.fastq.gz'):
+            open(os.path.join(self.top_dir,
+                              'test.MockIlluminaData',
+                              'fastqs',fq),'w').write('')
+        return os.path.join(self.top_dir,'test.MockIlluminaData')
+
     def test_illumina_data_all_sample_ids_differ_from_sample_names(self):
         """Read bcl2fastq2 output when all sample ids differ from names
 
@@ -609,6 +621,16 @@ class TestIlluminaDataForBcl2fastq2SpecialCases(BaseTestIlluminaData):
         # Attempt to read the directory as if it were the output
         # from bcl2fastq v2
         dirn = self.makeNonIlluminaDataDirectoryWithFastqs()
+        self.assertRaises(IlluminaDataError,IlluminaData,
+                          os.path.dirname(dirn),
+                          unaligned_dir=os.path.basename(dirn))
+
+    def test_illumina_data_not_bcl2fastq2_output_non_canonical_fastqs(self):
+        """Reading non-bcl2fastq v2 output directory with non-canonical Fastqs raises exception
+        """
+        # Attempt to read the directory as if it were the output
+        # from bcl2fastq v2
+        dirn = self.makeNonIlluminaDataDirectoryWithNonCanonicalFastqs()
         self.assertRaises(IlluminaDataError,IlluminaData,
                           os.path.dirname(dirn),
                           unaligned_dir=os.path.basename(dirn))
@@ -839,6 +861,15 @@ class TestIlluminaFastq(unittest.TestCase):
         self.assertEqual(fq.read_number,1)
         self.assertEqual(fq.set_number,1)
         self.assertEqual(str(fq),fastq_name)
+
+    def test_illumina_fastq_for_non_canonical_fastq_names(self):
+        """
+        Check non-canonical Fastq names raise IlluminaDataError
+        """
+        fastq_name = 'PB04_S4_R1_unpaired.fastq.gz'
+        self.assertRaises(IlluminaDataError,IlluminaFastq,fastq_name)
+        fastq_name = 'PB04_trimmoPE_bowtie2_notHg38.1.fastq.gz'
+        self.assertRaises(IlluminaDataError,IlluminaFastq,fastq_name)
 
 class TestSampleSheet(unittest.TestCase):
     def setUp(self):

--- a/bcftbx/test/test_IlluminaData.py
+++ b/bcftbx/test/test_IlluminaData.py
@@ -4,6 +4,7 @@
 from bcftbx.IlluminaData import *
 from bcftbx.mock import MockIlluminaRun
 from bcftbx.mock import MockIlluminaData
+from bcftbx.TabFile import TabDataLine
 import bcftbx.utils
 import unittest
 import cStringIO
@@ -2420,6 +2421,86 @@ class TestSplitRunName(unittest.TestCase):
                          (None,None,None))
         self.assertEqual(split_run_name('1402100_M00879_XYZ'),
                          (None,None,None))
+
+class TestSampleSheetIndexSequence(unittest.TestCase):
+
+    def test_casava_single_index(self):
+        """samplesheet_index_sequence: check CASAVA sample sheet single index
+        """
+        line = TabDataLine(line="FC1,1,AB_control,,CGATGT,,,,,Control",
+                           column_names=('FCID',
+                                         'Lane',
+                                         'SampleID',
+                                         'SampleRef',
+                                         'Index',
+                                         'Description',
+                                         'Control',
+                                         'Recipe',
+                                         'Operator',
+                                         'SampleProject'),
+                           delimiter=",")
+        self.assertEqual(samplesheet_index_sequence(line),'CGATGT')
+
+    def test_casava_dual_index(self):
+        """samplesheet_index_sequence: check CASAVA sample sheet dual index
+        """
+        line = TabDataLine(line="FC1,1,C01,,TAAGGCGA-GCGTAAGA,,,,,KP",
+                           column_names=('FCID',
+                                         'Lane',
+                                         'SampleID',
+                                         'SampleRef',
+                                         'Index',
+                                         'Description',
+                                         'Control',
+                                         'Recipe',
+                                         'Operator',
+                                         'SampleProject'),
+                           delimiter=",")
+        self.assertEqual(samplesheet_index_sequence(line),'TAAGGCGA-GCGTAAGA')
+
+    def test_iem_single_index(self):
+        """samplesheet_index_sequence: check IEM4 sample sheet single index
+        """
+        line = TabDataLine(line="1,ABT1,ABT1,,,A002,CGATGT,AB,",
+                           column_names=('Lane',
+                                         'Sample_ID',
+                                         'Sample_Name',
+                                         'Sample_Plate',
+                                         'Sample_Well',
+                                         'I7_Index_ID',
+                                         'index',
+                                         'Sample_Project',
+                                         'Description'),
+                           delimiter=",")
+        self.assertEqual(samplesheet_index_sequence(line),'CGATGT')
+
+    def test_iem_dual_index(self):
+        """samplesheet_index_sequence: check IEM4 sample sheet dual index
+        """
+        line = TabDataLine(line="1,S1,S1,,,D701,CGTGTAGG,D501,GACCTGTA,HO,",
+                           column_names=('Lane',
+                                         'Sample_ID',
+                                         'Sample_Name',
+                                         'Sample_Plate',
+                                         'Sample_Well',
+                                         'I7_Index_ID',
+                                         'index',
+                                         'I5_Index_ID',
+                                         'index2',
+                                         'Sample_Project',
+                                         'Description'),
+                           delimiter=",")
+        self.assertEqual(samplesheet_index_sequence(line),'CGTGTAGG-GACCTGTA')
+
+class TestNormaliseBarcode(unittest.TestCase):
+    def test_normalise_barcode(self):
+        self.assertEqual(normalise_barcode('CGATGT'),'CGATGT')
+        self.assertEqual(normalise_barcode('CGTGTAGG-GACCTGTA'),
+                         'CGTGTAGGGACCTGTA')
+        self.assertEqual(normalise_barcode('CGTGTAGG+GACCTGTA'),
+                         'CGTGTAGGGACCTGTA')
+        self.assertEqual(normalise_barcode('CGTGTAGGGACCTGTA'),
+                         'CGTGTAGGGACCTGTA')
 
 #######################################################################
 # Main program

--- a/bcftbx/test/test_IlluminaData.py
+++ b/bcftbx/test/test_IlluminaData.py
@@ -2492,6 +2492,19 @@ class TestSampleSheetIndexSequence(unittest.TestCase):
                            delimiter=",")
         self.assertEqual(samplesheet_index_sequence(line),'CGTGTAGG-GACCTGTA')
 
+    def test_iem_no_index(self):
+        """samplesheet_index_sequence: check IEM4 sample sheet no index column
+        """
+        line = TabDataLine(line="PB2,PB2,,,PB,",
+                         column_names=('Sample_ID',
+                                       'Sample_Name',
+                                       'Sample_Plate',
+                                       'Sample_Well',
+                                       'Sample_Project',
+                                       'Description'),
+                           delimiter=",")
+        self.assertEqual(samplesheet_index_sequence(line),None)
+
 class TestNormaliseBarcode(unittest.TestCase):
     def test_normalise_barcode(self):
         self.assertEqual(normalise_barcode('CGATGT'),'CGATGT')


### PR DESCRIPTION
PR to address failures when the `IlluminaFastq` and `IlluminaData` classes try to handle "non-canonical" Fastq names e.g.

    PB04_S4_R1_unpaired.fastq.gz
    PB04_trimmoPE_bowtie2_notHg38.1.fastq.gz