### PR TITLE
Capture the exit status of jobs from JobRunner and Pipeline.Job classes

### DIFF
--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -365,13 +365,18 @@ class GEJobRunner(BaseJobRunner):
     queue on initialisation.
     """
 
-    def __init__(self,queue=None,log_dir=None,ge_extra_args=None):
+    def __init__(self,queue=None,log_dir=None,ge_extra_args=None,
+                 poll_interval=1.0,timeout=30.0):
         """Create a new GEJobRunner instance
 
         Arguments:
           queue:   Name of GE queue to use (set to 'None' to use default queue)
           log_dir: Directory to write log files to (set to 'None' to use cwd)
           ge_extra_args: Arbitrary additional arguments to supply to qsub
+          poll_interval: time interval to use when polling Grid Engine e.g.
+            to acquire qacct information (default 1s)
+          timeout: maximum length of time to wait before giving up when
+            polling Grid Engine (default 30s)
         """
         self.__queue = queue
         # Directory for log files
@@ -379,7 +384,11 @@ class GEJobRunner(BaseJobRunner):
         # Keep track of names and log dirs for each job
         self.__names = {}
         self.__log_dirs = {}
+        self.__exit_status = {}
         self.__ge_extra_args = ge_extra_args
+        # Polling intervals and timeout periods (seconds)
+        self.__ge_poll_interval = poll_interval
+        self.__ge_timeout = timeout
 
     def __repr__(self):
         name = 'GEJobRunner'
@@ -450,7 +459,9 @@ class GEJobRunner(BaseJobRunner):
         if not os.path.exists(cwd):
             logging.error("QsubScript: cwd doesn't exist!")
             return None
-        p = subprocess.Popen(qsub,cwd=cwd,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
+        p = subprocess.Popen(qsub,cwd=cwd,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
         p.wait()
         # Check stderr
         error = p.stderr.read().strip()
@@ -544,6 +555,44 @@ class GEJobRunner(BaseJobRunner):
                 job_ids.append(job_data[0])
         return job_ids
 
+    def exit_status(self,job_id):
+        """Return exit status from command run by a job
+        """
+        if job_id in self.__exit_status:
+            # Return cached exit status
+            return self.__exit_status[job_id]
+        if self.isRunning(job_id):
+            # Return None if job is still running
+            return None
+        # Try to get qacct info
+        # This might not be available immediately after the job
+        # completes as the accounting system will only flush the
+        # information periodically
+        # Therefore we will retry retrieval based on the polling
+        # interval and timeout period defined on initialisation
+        job_info = self.__run_qacct(job_id)
+        retries = 0
+        while not job_info and \
+              (retries*self.__ge_poll_interval) < self.__ge_timeout:
+            time.sleep(self.__ge_poll_interval)
+            job_info = self.__run_qacct(job_id)
+            retries += 1
+        logging.debug("qacct: %s (%s retries), returned %s" %
+                      (job_id,retries,job_info))
+        # Check if we have qacct info after multiple attempts
+        if not job_info:
+            logging.warning("No qacct info for job %s after %d attempts" %
+                            (job_id,retries))
+            return None
+        # Extract, store and return exit status
+        try:
+            exit_status = int(job_info['exit_status'])
+            self.__exit_status[job_id] = exit_status
+            return exit_status
+        except KeyError:
+            logging.error("No exit_status returned for job %s" % job_id)
+            return None
+
     def __run_qstat(self):
         """Internal: run qstat and return data as a list of lists
 
@@ -576,6 +625,81 @@ class GEJobRunner(BaseJobRunner):
                 # Skip this line
                 pass
         return jobs
+
+    def __run_qacct(self,job_id):
+        """Internal: run qacct and return data as a dictionary
+
+        Runs 'qacct -j' command to get the accounting information
+        for the specified job ID, processes the output and returns
+        it as a dictionary, for example:
+
+        { 'qname': 'serial.q', 'exit_status': '0', ... }
+
+        The full set of accounting parameters are listed in the
+        Grid Engine 'accounting (5)' manpage, for example:
+
+        https://arc.liv.ac.uk/SGE/htmlman/htmlman5/accounting.html
+
+        Note also that there may be a lag between job completion
+        and the accounting information becoming available to qacct.
+        According to the documentation this interval is governed
+        by the `accounting_flush_time` parameter in the
+        `reporting_params` line of the Grid Engine configuration
+        file - for example:
+
+        > grep $SGE_ROOT/$SGE_CELL/common/configuration
+        reporting_params             accounting=true reporting=false flush_time=00:00:15 joblog=false sharelog=00:00:00
+
+        NB it is also possible that accounting is turned off and
+        that no information is available at all.
+
+        """
+        cmd = ['qacct','-j',"%s" % job_id]
+        # Run the qacct command
+        p = subprocess.Popen(cmd,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+        p.wait()
+        # Check stderr in case output is not available
+        # e.g. "error: job id 18384 not found"
+        stderr = p.stderr.read()
+        if stderr.startswith("error: job id"):
+            logging.warning("Job %s: uable to get qacct info"
+                            % job_id)
+            return None
+        # Process the output
+        qacct_dict = {}
+        # Typical output is:
+        # qname        serial.q
+        # hostname     node015.prv.cluster
+        # group        users
+        # owner        pjb
+        # jobname      copy.MH
+        # jobnumber    9859
+        # taskid       undefined
+        # account      sge
+        # priority     0
+        # qsub_time    Thu Aug 18 11:28:50 2016
+        # start_time   Thu Aug 18 11:28:50 2016
+        # end_time     Thu Aug 18 12:27:09 2016
+        # granted_pe   NONE
+        # slots        1
+        # failed       0
+        # exit_status  0
+        # ...
+        # i.e. key-value pairs, one pair per line
+        print "__run_qacct: stdout for %s:" % job_id
+        for line in p.stdout:
+            print line.rstrip()
+            try:
+                i = line.index(" ")
+                key = line[:i].strip()
+                value = line[i:].strip()
+                qacct_dict[key] = value
+            except ValueError:
+                # Skip this line
+                pass
+        return qacct_dict
 
     def __job_state_code(self,job_id):
         """Internal: get the state code for the specified job id

--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -282,8 +282,8 @@ class SimpleJobRunner(BaseJobRunner):
             return False
         # Attempt to terminate
         logging.debug("KillJob: deleting job")
-        kill=('kill','-9',job_id)
-        p = subprocess.Popen(kill)
+        p = self.__job_popen[job_id]
+        p.terminate()
         p.wait()
         if job_id not in self.list():
             logging.debug("KillJob: deleted job %s" % job_id)

--- a/bcftbx/test/test_JobRunner.py
+++ b/bcftbx/test/test_JobRunner.py
@@ -224,14 +224,30 @@ class TestGEJobRunner(unittest.TestCase):
         # Create a runner and execute the echo command
         runner = GEJobRunner(ge_extra_args=self.ge_extra_args)
         jobid = self.run_job(runner,'test',self.working_dir,'echo',('this is a test',))
+        self.assertEqual(runner.exit_status(jobid),None)
         self.wait_for_jobs(runner,jobid)
         # Check outputs
         self.assertEqual(runner.name(jobid),'test')
         self.assertTrue(os.path.isfile(runner.logFile(jobid)))
         self.assertTrue(os.path.isfile(runner.errFile(jobid)))
+        self.assertEqual(runner.exit_status(jobid),0)
         # Check log files are in the working directory
         self.assertEqual(os.path.dirname(runner.logFile(jobid)),self.working_dir)
         self.assertEqual(os.path.dirname(runner.errFile(jobid)),self.working_dir)
+
+    def test_ge_job_runner_exit_status(self):
+        """Test GEJobRunner returns correct exit status
+        """
+        # Create a runner and execute commands with known exit codes
+        runner = GEJobRunner(ge_extra_args=self.ge_extra_args)
+        jobid_ok = self.run_job(runner,'test_ok',self.working_dir,
+                                       '/bin/bash',('-c','\'exit 0\'',))
+        jobid_error = self.run_job(runner,'test_error',self.working_dir,
+                                   '/bin/bash',('-c','\'exit 1\'',))
+        self.wait_for_jobs(runner,jobid_ok,jobid_error)
+        # Check exit codes
+        self.assertEqual(runner.exit_status(jobid_ok),0)
+        self.assertEqual(runner.exit_status(jobid_error),1)
 
     def test_ge_job_runner_termination(self):
         """Test GEJobRunner can terminate a running job
@@ -250,6 +266,7 @@ class TestGEJobRunner(unittest.TestCase):
         # Terminate job
         runner.terminate(jobid)
         self.assertFalse(runner.isRunning(jobid))
+        self.assertNotEqual(runner.exit_status(jobid),0)
 
     def test_ge_job_runner_join_logs(self):
         """Test GEJobRunner with '-j y' option (i.e. join stderr and stdout)

--- a/bcftbx/test/test_Pipeline.py
+++ b/bcftbx/test/test_Pipeline.py
@@ -121,7 +121,7 @@ class TestJobWithGEJobRunner(unittest.TestCase):
     def make_tmp_dir(self):
         return tempfile.mkdtemp()
 
-    def test_job_with_simplejobrunner(self):
+    def test_job_with_gejobrunner(self):
         """Test Job using GEJobRunner to run basic shell command
         """
         # Create a job
@@ -161,9 +161,12 @@ class TestJobWithGEJobRunner(unittest.TestCase):
         self.assertTrue(job.isRunning())
         self.assertFalse(job.errorState())
         self.assertEqual(job.status(),"Running")
-        # Wait to let job complete and check last time
-        time.sleep(2)
-        job.update()
+        # Wait for job to complete and check last time
+        ntries = 1
+        timeout = 20
+        while job.isRunning() and ntries < timeout:
+            ntries += 1
+            time.sleep(1)
         self.assertEqual(job.name,"shell_cmd")
         self.assertEqual(job.working_dir,self.working_dir)
         self.assertEqual(job.script,cmd)

--- a/bcftbx/test/test_Pipeline.py
+++ b/bcftbx/test/test_Pipeline.py
@@ -90,6 +90,33 @@ class TestJobWithSimpleJobRunner(unittest.TestCase):
         self.assertFalse(job.errorState())
         self.assertEqual(job.status(),"Finished")
 
+    def test_failing_job_with_simplejobrunner(self):
+        """Test Job using SimpleJobRunner to run failing shell command
+        """
+        # Create a job
+        cmd = "ls"
+        args = ("*.whereisit",)
+        job = Job(SimpleJobRunner(),"failing_cmd",self.working_dir,cmd,args)
+        # Start the job
+        job_id = job.start()
+        # Wait to let job complete and check
+        time.sleep(1)
+        job.update()
+        self.assertEqual(job.name,"failing_cmd")
+        self.assertEqual(job.working_dir,self.working_dir)
+        self.assertEqual(job.script,cmd)
+        self.assertEqual(job.args,args)
+        self.assertEqual(job.label,None)
+        self.assertEqual(job.group_label,None)
+        self.assertEqual(job.job_id,job_id)
+        self.assertNotEqual(job.log,None)
+        self.assertNotEqual(job.start_time,None)
+        self.assertNotEqual(job.end_time,None)
+        self.assertFalse(job.isRunning())
+        self.assertEqual(job.exit_status,2)
+        self.assertFalse(job.errorState())
+        self.assertEqual(job.status(),"Finished")
+
 class TestJobWithGEJobRunner(unittest.TestCase):
     """Unit tests for the the Job class using GEJobRunner
 
@@ -179,6 +206,36 @@ class TestJobWithGEJobRunner(unittest.TestCase):
         self.assertNotEqual(job.end_time,None)
         self.assertFalse(job.isRunning())
         self.assertEqual(job.exit_status,0)
+        self.assertFalse(job.errorState())
+        self.assertEqual(job.status(),"Finished")
+
+    def test_failing_job_with_gejobrunner(self):
+        """Test Job using GeJobRunner to run failing shell command
+        """
+        # Create a job
+        cmd = "ls"
+        args = ("*.whereisit",)
+        job = Job(GEJobRunner(),"failing_cmd",self.working_dir,cmd,args)
+        # Start the job
+        job_id = job.start()
+        # Wait to let job complete and check
+        ntries = 1
+        timeout = 20
+        while job.isRunning() and ntries < timeout:
+            ntries += 1
+            time.sleep(1)
+        self.assertEqual(job.name,"failing_cmd")
+        self.assertEqual(job.working_dir,self.working_dir)
+        self.assertEqual(job.script,cmd)
+        self.assertEqual(job.args,args)
+        self.assertEqual(job.label,None)
+        self.assertEqual(job.group_label,None)
+        self.assertEqual(job.job_id,job_id)
+        self.assertNotEqual(job.log,None)
+        self.assertNotEqual(job.start_time,None)
+        self.assertNotEqual(job.end_time,None)
+        self.assertFalse(job.isRunning())
+        self.assertEqual(job.exit_status,2)
         self.assertFalse(job.errorState())
         self.assertEqual(job.status(),"Finished")
 

--- a/bcftbx/test/test_Pipeline.py
+++ b/bcftbx/test/test_Pipeline.py
@@ -2,7 +2,171 @@
 # Tests for Pipeline.py module
 #######################################################################
 import unittest
-from bcftbx.Pipeline import *
+import tempfile
+import shutil
+import time
+import bcftbx.utils
+from bcftbx.JobRunner import SimpleJobRunner
+from bcftbx.JobRunner import GEJobRunner
+from bcftbx.Pipeline import Job
+from bcftbx.Pipeline import GetSolidDataFiles
+from bcftbx.Pipeline import GetSolidPairedEndFiles
+from bcftbx.Pipeline import GetFastqFiles
+from bcftbx.Pipeline import GetFastqGzFiles
+
+class TestJobWithSimpleJobRunner(unittest.TestCase):
+    """Unit tests for the the Job class using SimpleJobRunner
+
+    """
+    def setUp(self):
+        # Create a temporary directory to work in
+        self.working_dir = self.make_tmp_dir()
+        self.log_dir = None
+
+    def tearDown(self):
+        shutil.rmtree(self.working_dir)
+        if self.log_dir is not None:
+            shutil.rmtree(self.log_dir)
+
+    def make_tmp_dir(self):
+        return tempfile.mkdtemp()
+
+    def test_job_with_simplejobrunner(self):
+        """Test Job using SimpleJobRunner to run basic shell command
+        """
+        # Create a job
+        cmd = "sleep"
+        args = ("2",)
+        job = Job(SimpleJobRunner(),"shell_cmd",self.working_dir,cmd,args)
+        # Check properties before starting
+        self.assertEqual(job.name,"shell_cmd")
+        self.assertEqual(job.working_dir,self.working_dir)
+        self.assertEqual(job.script,cmd)
+        self.assertEqual(job.args,args)
+        self.assertEqual(job.label,None)
+        self.assertEqual(job.group_label,None)
+        self.assertEqual(job.job_id,None)
+        self.assertEqual(job.log,None)
+        self.assertEqual(job.start_time,None)
+        self.assertEqual(job.end_time,None)
+        self.assertEqual(job.exit_status,None)
+        # Check status
+        self.assertFalse(job.isRunning())
+        self.assertFalse(job.errorState())
+        self.assertEqual(job.status(),"Waiting")
+        # Start the job and check
+        job_id = job.start()
+        time.sleep(1)
+        self.assertEqual(job.name,"shell_cmd")
+        self.assertEqual(job.working_dir,self.working_dir)
+        self.assertEqual(job.script,cmd)
+        self.assertEqual(job.args,args)
+        self.assertEqual(job.label,None)
+        self.assertEqual(job.group_label,None)
+        self.assertEqual(job.job_id,job_id)
+        self.assertNotEqual(job.log,None)
+        self.assertNotEqual(job.start_time,None)
+        self.assertEqual(job.end_time,None)
+        self.assertEqual(job.exit_status,None)
+        self.assertTrue(job.isRunning())
+        self.assertFalse(job.errorState())
+        self.assertEqual(job.status(),"Running")
+        # Wait to let job complete and check last time
+        time.sleep(2)
+        job.update()
+        self.assertEqual(job.name,"shell_cmd")
+        self.assertEqual(job.working_dir,self.working_dir)
+        self.assertEqual(job.script,cmd)
+        self.assertEqual(job.args,args)
+        self.assertEqual(job.label,None)
+        self.assertEqual(job.group_label,None)
+        self.assertEqual(job.job_id,job_id)
+        self.assertNotEqual(job.log,None)
+        self.assertNotEqual(job.start_time,None)
+        self.assertNotEqual(job.end_time,None)
+        self.assertFalse(job.isRunning())
+        self.assertEqual(job.exit_status,0)
+        self.assertFalse(job.errorState())
+        self.assertEqual(job.status(),"Finished")
+
+class TestJobWithGEJobRunner(unittest.TestCase):
+    """Unit tests for the the Job class using GEJobRunner
+
+    """
+    def setUp(self):
+        # Skip the test if Grid Engine not available
+        if bcftbx.utils.find_program('qstat') is None:
+            raise unittest.SkipTest("'qstat' not found, Grid Engine "
+                                    "not available")
+        # Create a temporary directory to work in
+        self.working_dir = self.make_tmp_dir()
+        self.log_dir = None
+
+    def tearDown(self):
+        shutil.rmtree(self.working_dir)
+        if self.log_dir is not None:
+            shutil.rmtree(self.log_dir)
+
+    def make_tmp_dir(self):
+        return tempfile.mkdtemp()
+
+    def test_job_with_simplejobrunner(self):
+        """Test Job using GEJobRunner to run basic shell command
+        """
+        # Create a job
+        cmd = "sleep"
+        args = ("2",)
+        job = Job(GEJobRunner(),"shell_cmd",self.working_dir,cmd,args)
+        # Check properties before starting
+        self.assertEqual(job.name,"shell_cmd")
+        self.assertEqual(job.working_dir,self.working_dir)
+        self.assertEqual(job.script,cmd)
+        self.assertEqual(job.args,args)
+        self.assertEqual(job.label,None)
+        self.assertEqual(job.group_label,None)
+        self.assertEqual(job.job_id,None)
+        self.assertEqual(job.log,None)
+        self.assertEqual(job.start_time,None)
+        self.assertEqual(job.end_time,None)
+        self.assertEqual(job.exit_status,None)
+        # Check status
+        self.assertFalse(job.isRunning())
+        self.assertFalse(job.errorState())
+        self.assertEqual(job.status(),"Waiting")
+        # Start the job and check
+        job_id = job.start()
+        time.sleep(1)
+        self.assertEqual(job.name,"shell_cmd")
+        self.assertEqual(job.working_dir,self.working_dir)
+        self.assertEqual(job.script,cmd)
+        self.assertEqual(job.args,args)
+        self.assertEqual(job.label,None)
+        self.assertEqual(job.group_label,None)
+        self.assertEqual(job.job_id,job_id)
+        self.assertNotEqual(job.log,None)
+        self.assertNotEqual(job.start_time,None)
+        self.assertEqual(job.end_time,None)
+        self.assertEqual(job.exit_status,None)
+        self.assertTrue(job.isRunning())
+        self.assertFalse(job.errorState())
+        self.assertEqual(job.status(),"Running")
+        # Wait to let job complete and check last time
+        time.sleep(2)
+        job.update()
+        self.assertEqual(job.name,"shell_cmd")
+        self.assertEqual(job.working_dir,self.working_dir)
+        self.assertEqual(job.script,cmd)
+        self.assertEqual(job.args,args)
+        self.assertEqual(job.label,None)
+        self.assertEqual(job.group_label,None)
+        self.assertEqual(job.job_id,job_id)
+        self.assertNotEqual(job.log,None)
+        self.assertNotEqual(job.start_time,None)
+        self.assertNotEqual(job.end_time,None)
+        self.assertFalse(job.isRunning())
+        self.assertEqual(job.exit_status,0)
+        self.assertFalse(job.errorState())
+        self.assertEqual(job.status(),"Finished")
 
 class TestGetSolidDataFiles(unittest.TestCase):
     """Unit tests for GetSolidDataFiles function

--- a/bcftbx/test/test_Pipeline.py
+++ b/bcftbx/test/test_Pipeline.py
@@ -1,6 +1,7 @@
 #######################################################################
 # Tests for Pipeline.py module
 #######################################################################
+import os
 import unittest
 import tempfile
 import shutil
@@ -99,6 +100,16 @@ class TestJobWithGEJobRunner(unittest.TestCase):
             raise unittest.SkipTest("'qstat' not found, Grid Engine "
                                     "not available")
         # Create a temporary directory to work in
+        # Nb can't make it in /tmp because that might not be
+        # shared between submit host and the compute node
+        # so check that TMPDIR is set and skip test if not
+        try:
+            tmpdir = os.environ['TMPDIR']
+        except KeyError:
+            raise unittest.SkipTest("'TMPDIR' environment variable not set - "
+                                    "set this to point to a temporary dir "
+                                    "shared by submit and compute nodes")
+        # Set up working dir
         self.working_dir = self.make_tmp_dir()
         self.log_dir = None
 


### PR DESCRIPTION
PR to implement the suggestions in issue #27, to capture the exit status of commands run by the various `JobRunner` classes and the `Pipeline.Job` class so that it's available to the calling subprogram.