### PR TITLE
Update samplesheet prediction and checking

### DIFF
--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -1719,6 +1719,10 @@ class SampleSheetPredictor(object):
                 sample_name = str(line[sample_sheet.sample_name_column])
             except TypeError:
                 sample_name = sample_id
+            if not sample_id:
+                sample_id = None
+            if not sample_name:
+                sample_name = None
             project = self.add_project(project_name)
             sample = project.add_sample(sample_id,
                                         sample_name=sample_name)
@@ -1885,9 +1889,10 @@ class SampleSheetProject(object):
             supplied project name
 
         """
-        if (sample_id is not None) and \
-           (sample_name is not None) and \
-           (sample_id != sample_name):
+        if sample_id is None:
+            # Special case: no ID defined, use name instead
+            sample_id = sample_name
+        elif sample_name is not None and sample_id != sample_name:
             # Special case when ID and name differ, then swap
             # over names
             sample_id,sample_name = sample_name,sample_id

--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -1885,6 +1885,12 @@ class SampleSheetProject(object):
             supplied project name
 
         """
+        if (sample_id is not None) and \
+           (sample_name is not None) and \
+           (sample_id != sample_name):
+            # Special case when ID and name differ, then swap
+            # over names
+            sample_id,sample_name = sample_name,sample_id
         try:
             return self.get_sample(sample_id)
         except KeyError:
@@ -1967,7 +1973,10 @@ class SampleSheetSample(object):
         if self._predict_for_package == "casava":
             return "Sample_%s" % self.sample_id
         elif self._predict_for_package == "bcl2fastq2":
-            return None
+            if self.sample_id != self.sample_name:
+                return self.sample_name
+            else:
+                return None
         
     def add_barcode(self,barcode_seq,lane=None):
         """
@@ -2032,11 +2041,6 @@ class SampleSheetSample(object):
                                      lane,
                                      read)
                             predicted_fastqs.append(fastq)
-            # Prepend sample name if different from the id
-            if self.sample_id != self.sample_name:
-                predicted_fastqs = ["%s/%s" % (self.sample_name,
-                                               fastq)
-                                    for fastq in predicted_fastqs]
         elif self._predict_for_package == "casava":
             for barcode_seq in self.barcode_seqs:
                 if self._predict_for_lanes:

--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -1844,7 +1844,8 @@ class SampleSheetProject(object):
         Return a list of sample ID's in the project
 
         """
-        return sorted([s.sample_id for s in self.samples])
+        return sorted([s.sample_id for s in self.samples],
+                      cmp=lambda x,y: cmp_sample_names(x,y))
 
     @property
     def dir_name(self):
@@ -2617,3 +2618,26 @@ def normalise_barcode(seq):
 
     """
     return str(seq).upper().replace('-','').replace('+','')
+
+def cmp_sample_names(s1,s2):
+    """
+    Compare two sample names and return integer depending on the outcome
+
+    The sample names are compared first by prefix and then by index.
+
+    Arguments:
+      s1 (str): first sample name
+      s2 (str): second sample name
+
+    Returns:
+      Integer: the return value is negative if s1 < s2, zero if
+      s1 == s2 and strictly positive if s1 > s2.
+
+    """
+    prefix1 = utils.extract_prefix(s1)
+    prefix2 = utils.extract_prefix(s2)
+    if prefix1 != prefix2:
+        return cmp(prefix1,prefix2)
+    indx1 = utils.extract_index(s1)
+    indx2 = utils.extract_index(s2)
+    return cmp(indx1,indx2)

--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -2630,12 +2630,18 @@ def samplesheet_index_sequence(line):
     # Index sequence
     try:
         # Try dual-indexed IEM4 format
+        if not line['index2'].strip():
+            # Blank index2, raise exception to break
+            raise KeyError
         return "%s-%s" % (line['index'].strip(),
                           line['index2'].strip())
     except KeyError:
         pass
     # Try single indexed IEM4 (no index2)
     try:
+        if not line['index'].strip():
+            # Blank index, raise exception to break
+            raise KeyError
         return line['index'].strip()
     except KeyError:
         pass

--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -2036,6 +2036,25 @@ class SampleSheetSample(object):
                 predicted_fastqs = ["%s/%s" % (self.sample_name,
                                                fastq)
                                     for fastq in predicted_fastqs]
+        elif self._predict_for_package == "casava":
+            for barcode_seq in self.barcode_seqs:
+                if self.lanes(barcode_seq):
+                    for lane in self.lanes(barcode_seq):
+                        for read in reads:
+                            fastq = "%s_%s_L%03d_R%d_001.fastq.gz" % \
+                                    (self.sample_id,
+                                     barcode_seq,
+                                     lane,read)
+                            predicted_fastqs.append(fastq)
+                else:
+                    # Add a single fastq per read for lane 1
+                    for read in reads:
+                        fastq = "%s_%s_L001_R%d_001.fastq.gz" % \
+                                (self.sample_id,
+                                 barcode_seq,
+                                 read)
+                        predicted_fastqs.append(fastq)
+        # Return predicted Fastqs
         return predicted_fastqs
 
     def set(self,package="bcl2fastq2",paired_end=False,

--- a/bcftbx/test/test_IlluminaData.py
+++ b/bcftbx/test/test_IlluminaData.py
@@ -3102,6 +3102,16 @@ class TestNormaliseBarcode(unittest.TestCase):
         self.assertEqual(normalise_barcode('CGTGTAGGGACCTGTA'),
                          'CGTGTAGGGACCTGTA')
 
+class TestCmpSampleNames(unittest.TestCase):
+    def test_cmp_sample_names(self):
+        self.assertTrue(cmp_sample_names("PJB01","PJB02") < 0)
+        self.assertTrue(cmp_sample_names("PJB02","PJB01") > 0)
+        self.assertEqual(cmp_sample_names("PJB01","PJB01"),0)
+        self.assertTrue(cmp_sample_names("PJB01","PJB10") < 0)
+        self.assertTrue(cmp_sample_names("PJB1","PJB10") < 0)
+        self.assertTrue(cmp_sample_names("ABC10","PJB10") < 0)
+        self.assertTrue(cmp_sample_names("PJB10","ABC10") > 0)
+
 #######################################################################
 # Main program
 #######################################################################

--- a/bcftbx/test/test_IlluminaData.py
+++ b/bcftbx/test/test_IlluminaData.py
@@ -1905,11 +1905,11 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         # Predict output fastqs CASAVA/bcl2fastq 1.8*
         predictor.set(package="casava")
         self.assertEqual(project.dir_name,"Project_PeterBriggs")
-        self.assertEqual(sample1.dir_name,"Sample_PJB1")
+        self.assertEqual(sample1.dir_name,"Sample_PJB1-1579")
         self.assertEqual(sample1.fastqs(),
                          ["PJB1-1579_CGATGTAT-TCTTTCCC_L001_R1_001.fastq.gz",
                           "PJB1-1579_CGATGTAT-TCTTTCCC_L002_R1_001.fastq.gz"])
-        self.assertEqual(sample2.dir_name,"Sample_PJB2")
+        self.assertEqual(sample2.dir_name,"Sample_PJB2-1580")
         self.assertEqual(sample2.fastqs(),
                          ["PJB2-1580_TGACCAAT-TCTTTCCC_L001_R1_001.fastq.gz",
                           "PJB2-1580_TGACCAAT-TCTTTCCC_L002_R1_001.fastq.gz"])
@@ -1917,13 +1917,13 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         predictor.set(package="casava",
                       paired_end=True)
         self.assertEqual(project.dir_name,"Project_PeterBriggs")
-        self.assertEqual(sample1.dir_name,"Sample_PJB1")
+        self.assertEqual(sample1.dir_name,"Sample_PJB1-1579")
         self.assertEqual(sample1.fastqs(),
                          ["PJB1-1579_CGATGTAT-TCTTTCCC_L001_R1_001.fastq.gz",
                           "PJB1-1579_CGATGTAT-TCTTTCCC_L001_R2_001.fastq.gz",
                           "PJB1-1579_CGATGTAT-TCTTTCCC_L002_R1_001.fastq.gz",
                           "PJB1-1579_CGATGTAT-TCTTTCCC_L002_R2_001.fastq.gz"])
-        self.assertEqual(sample2.dir_name,"Sample_PJB2")
+        self.assertEqual(sample2.dir_name,"Sample_PJB2-1580")
         self.assertEqual(sample2.fastqs(),
                          ["PJB2-1580_TGACCAAT-TCTTTCCC_L001_R1_001.fastq.gz",
                           "PJB2-1580_TGACCAAT-TCTTTCCC_L001_R2_001.fastq.gz",
@@ -2157,12 +2157,14 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         # Predict output fastqs bcl2fastq2
         predictor.set(package="bcl2fastq2")
         self.assertEqual(project.dir_name,"PeterBriggs")
+        self.assertEqual(sample1.dir_name,"PJB1")
         self.assertEqual(sample1.fastqs(),
-                         ["PJB1/PJB1-1579_S1_L001_R1_001.fastq.gz",
-                          "PJB1/PJB1-1579_S1_L002_R1_001.fastq.gz"])
+                         ["PJB1-1579_S1_L001_R1_001.fastq.gz",
+                          "PJB1-1579_S1_L002_R1_001.fastq.gz"])
+        self.assertEqual(sample2.dir_name,"PJB2")
         self.assertEqual(sample2.fastqs(),
-                         ["PJB2/PJB2-1580_S2_L001_R1_001.fastq.gz",
-                          "PJB2/PJB2-1580_S2_L002_R1_001.fastq.gz"])
+                         ["PJB2-1580_S2_L001_R1_001.fastq.gz",
+                          "PJB2-1580_S2_L002_R1_001.fastq.gz"])
         # Predict output fastqs CASAVA/bcl2fastq 1.8*
         predictor.set(package="casava")
         self.assertEqual(project.dir_name,"Project_PeterBriggs")

--- a/bcftbx/test/test_IlluminaData.py
+++ b/bcftbx/test/test_IlluminaData.py
@@ -2023,7 +2023,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(sample1.fastqs(),
                          ["A8_TAAGGCGA-TAGATCGC_L001_R1_001.fastq.gz"])
         self.assertEqual(sample2.dir_name,"Sample_B8")
-        self.assertEqual(sample2.fastqs(package="casava"),
+        self.assertEqual(sample2.fastqs(),
                          ["B8_CGTACTAG-TAGATCGC_L001_R1_001.fastq.gz"])
         # Predict output fastqs CASAVA/bcl2fastq 1.8* paired end
         predictor.set(package="casava",
@@ -2132,12 +2132,10 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                           "886-1_ATGTCA_L007_R1_001.fastq.gz"])
 
     def test_samplesheet_predictor_iem_id_and_names_differ(self):
-        iem = SampleSheet(fp=cStringIO.StringIO(
-            self.hiseq_sample_sheet_id_and_name_differ_content))
-        """SampleSheetPredictor: handle IEM4 sample sheet with lanes
+        """SampleSheetPredictor: handle IEM4 sample sheet where sample ID differs from name
         """
         iem = SampleSheet(fp=cStringIO.StringIO(
-            self.hiseq_sample_sheet_content))
+            self.hiseq_sample_sheet_id_and_name_differ_content))
         predictor = SampleSheetPredictor(sample_sheet=iem)
         # Get projects
         self.assertEqual(predictor.nprojects,1)
@@ -2171,12 +2169,12 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(sample1.fastqs(),
                          ["PJB1-1579_CGATGTAT-TCTTTCCC_L001_R1_001.fastq.gz",
                           "PJB1-1579_CGATGTAT-TCTTTCCC_L002_R1_001.fastq.gz"])
-        self.assertEqual(sample2.fastqs(package="casava"),
+        self.assertEqual(sample2.fastqs(),
                          ["PJB2-1580_TGACCAAT-TCTTTCCC_L001_R1_001.fastq.gz",
                           "PJB2-1580_TGACCAAT-TCTTTCCC_L002_R1_001.fastq.gz"])
 
     def test_samplesheet_predictor_iem_no_barcodes(self):
-        """SampleSheetPredictor: handle IEM4 sample sheet with lanes
+        """SampleSheetPredictor: handle IEM4 sample sheet with no barcodes
         """
         iem = SampleSheet(fp=cStringIO.StringIO(
             self.hiseq_sample_sheet_no_barcodes))
@@ -2192,10 +2190,10 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         sample2 = project.get_sample("PJB2")
         self.assertRaises(KeyError,project.get_sample,"DoesntExist")
         # Check sample barcodes and lanes
-        self.assertEqual(sample1.barcode_seqs,[])
-        self.assertEqual(sample2.barcode_seqs,[])
-        self.assertEqual(sample1.lanes(),(1,))
-        self.assertEqual(sample2.lanes(),(2,))
+        self.assertEqual(sample1.barcode_seqs,["NoIndex"])
+        self.assertEqual(sample2.barcode_seqs,["NoIndex"])
+        self.assertEqual(sample1.lanes(),[1,])
+        self.assertEqual(sample2.lanes(),[2,])
         self.assertEqual(sample1.s_index,1)
         self.assertEqual(sample2.s_index,2)
         # Predict output fastqs bcl2fastq2
@@ -2208,9 +2206,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         # Predict output fastqs CASAVA/bcl2fastq 1.8*
         predictor.set(package="casava")
         self.assertEqual(project.dir_name,"Project_PeterBriggs")
-        self.assertEqual(sample1.fastqs(package="casava"),
+        self.assertEqual(sample1.fastqs(),
                          ["PJB1_NoIndex_L001_R1_001.fastq.gz"])
-        self.assertEqual(sample2.fastqs(package="casava"),
+        self.assertEqual(sample2.fastqs(),
                          ["PJB2_NoIndex_L002_R1_001.fastq.gz"])
     
 class TestMiseqToCasavaConversion(unittest.TestCase):

--- a/bcftbx/test/test_IlluminaData.py
+++ b/bcftbx/test/test_IlluminaData.py
@@ -2127,7 +2127,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                          ["885-1_AGTTCC_L003_R1_001.fastq.gz",
                           "885-1_AGTTCC_L006_R1_001.fastq.gz"])
         self.assertEqual(sample4.dir_name,"Sample_886-1")
-        self.assertEqual(sample3.fastqs(),
+        self.assertEqual(sample4.fastqs(),
                          ["886-1_ATGTCA_L004_R1_001.fastq.gz",
                           "886-1_ATGTCA_L007_R1_001.fastq.gz"])
 

--- a/illumina2cluster/prep_sample_sheet.py
+++ b/illumina2cluster/prep_sample_sheet.py
@@ -15,7 +15,7 @@ Prepare sample sheet file for Illumina sequencers.
 
 """
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 
 #######################################################################
 # Imports
@@ -287,8 +287,10 @@ if __name__ == "__main__":
                 sys.exit(1)
             for line in data:
                 if line['Lane'] in lanes:
-                    print "Setting SampleProject for lane %d: '%s'" % (line['Lane'],
-                                                                       name)
+                    print "Setting SampleProject for lane %d: '%s' " \
+                        " (%s)"% (line['Lane'],
+                                  name,
+                                  line[data.sample_id_column])
                     line[data.sample_project_column] = name
     # Truncate barcodes
     if options.barcode_len is not None:
@@ -322,9 +324,6 @@ if __name__ == "__main__":
     # Fix duplicates
     if options.fix_duplicates:
         data.fix_duplicated_names()
-    # Print transposed data in tab-delimited format
-    if options.view:
-        data.transpose().write(fp=sys.stdout,delimiter='\t')
     # Check for non-unique id/project combinations, spaces and empty names
     check_status = 0
     # Duplicated names
@@ -356,15 +355,31 @@ if __name__ == "__main__":
                             data.sample_id_column,
                             data.sample_project_column)
     # Predict outputs
-    if check_status == 0 or options.ignore_warnings:
-        projects = data.predict_output()
-        print "Predicted output:"
-        for project in projects:
-            print "%s (%d samples)" % (project,len(projects[project]))
-            for sample in projects[project]:
-                print "\t%s" % sample
-                for sub_sample in projects[project][sample]:
-                    print "\t\t%s" % sub_sample
+    if check_status == 0 or options.ignore_warnings or options.view:
+        predictor = IlluminaData.SampleSheetPredictor(sample_sheet=data)
+        title = "Predicted projects:"
+        print "\n%s\n%s" % (title,('='*len(title)))
+        for project_name in predictor.project_names:
+            print "- %s" % project_name
+        for project_name in predictor.project_names:
+            project = predictor.get_project(project_name)
+            title = "%s (%d samples)" % (project_name,
+                                       len(project.sample_ids))
+            print "\n%s\n%s" % (title,('-'*len(title)))
+            for sample_id in project.sample_ids:
+                sample = project.get_sample(sample_id)
+                for barcode in sample.barcode_seqs:
+                    lanes = sample.lanes(barcode)
+                    if lanes:
+                        lanes = "L%s" % (','.join([str(l)
+                                                   for l in lanes]))
+                    else:
+                        lanes = "L*"
+                    line = [sample_id,
+                            "S%d" % sample.s_index,
+                            barcode,
+                            lanes]
+                    print "%s" % '\t'.join([str(i) for i in line])
 
     # Write out new sample sheet
     if options.samplesheet_out:


### PR DESCRIPTION
PR to update how the prediction of sample sheet outputs is handled in `bcftbx/IlluminaData.py`, by implementing a new `SampleSheetPredictor` class.

The code is based on the predictor class originally found in `auto_process_ngs` PR 30:
https://github.com/fls-bioinformatics-core/auto_process_ngs/pull/30