### PR TITLE
Update QC to handle Fastq_screen v0.9.2

### DIFF
--- a/QC-pipeline/fastq_screen.sh
+++ b/QC-pipeline/fastq_screen.sh
@@ -93,7 +93,7 @@ if [ -z "$subset" ] || [ "$subset" == "0" ] ; then
 	    [0-4])
 		subset_option=
 		;;
-	    [5-7])
+	    [5-9])
 		if [ "$MINOR_VERSION" == "6" ] ; then
 		    case "$PATCH_VERSION" in
 			[0-2])

--- a/QC-pipeline/fastq_screen.sh
+++ b/QC-pipeline/fastq_screen.sh
@@ -188,7 +188,7 @@ for screen in $SCREENS ; do
 		    fastq_screen_txt=${fastq%.fastq}_screen.txt
 		    fastq_screen_png=${fastq%.fastq}_screen.png
 		    ;;
-		v0.[5-6])
+		v0.[5-9])
 		    fastq_screen_txt=${fastq_base}_screen.txt
 		    fastq_screen_png=${fastq_base}_screen.png
 		    ;;

--- a/QC-pipeline/fastq_screen.sh
+++ b/QC-pipeline/fastq_screen.sh
@@ -94,12 +94,14 @@ if [ -z "$subset" ] || [ "$subset" == "0" ] ; then
 		subset_option=
 		;;
 	    [5-7])
-		case "$PATCH_VERSION" in
-		    [0-2])
-			echo "ERROR --subset 0 broken for fastq_screen $FASTQ_SCREEN_VERSION; switch to 0.6.3 or later" >&2
-			exit 1
-			;;
-		esac
+		if [ "$MINOR_VERSION" == "6" ] ; then
+		    case "$PATCH_VERSION" in
+			[0-2])
+			    echo "ERROR --subset 0 broken for fastq_screen $FASTQ_SCREEN_VERSION; switch to 0.6.3 or later" >&2
+			    exit 1
+			    ;;
+		    esac
+		fi
 		subset_option="--subset 0"
 		;;
 	    *)

--- a/QC-pipeline/fastq_screen.sh
+++ b/QC-pipeline/fastq_screen.sh
@@ -121,6 +121,13 @@ if [ -z "$color" ] ; then
     # Letterspace indexes
     conf_ext=${FASTQ_SCREEN_CONF_NT_EXT}
 else
+    # --colorspace option removed in v0.6.0
+    if [ $MAJOR_VERSION == "v0" ] ; then
+	if [ $MINOR_VERSION -ge 6 ] ; then
+	    echo "ERROR --color option unavailable for fastq_screen $ASTQ_SCREEN_VERSION and later" >&2
+	    exit 1
+	fi
+    fi
     # Colorspace indexes
     conf_ext=${FASTQ_SCREEN_CONF_CS_EXT}
 fi

--- a/share/bcftbx.versions.sh
+++ b/share/bcftbx.versions.sh
@@ -36,7 +36,12 @@ function get_version() {
 	    fastq_screen)
 		# fastq_screen --version
 		# fastq_screen v0.3.1
-		echo `$get_version_exe --version | cut -d" " -f2`
+		# fastq_screen v0.4.2
+		# fastq_screen v0.5.2
+		# fastq_screen v0.6.2
+		# fastq_screen v0.7.0
+		# FastQ Screen v0.9.2
+		echo `$get_version_exe --version | tr -s '_' ' ' | cut -d" " -f3`
 		;;
 	    fastqc)
 		# fastqc -v


### PR DESCRIPTION
This PR updates the `fastq_screen.sh` script in the `QC-pipeline` directory to handle the latest version of Babraham's Fastq Screen program.

The updates include:

 * Ensure that only versions between 0.6.0 and 0.6.2 trigger premature exit for `--subset 0`
 * Exit if `--color` option is specified for versions 0.6.0 and later (as it's no longer supported)
 * Handle new format for version string output by `fastq_screen --version` for 0.9.2
 * Ensure script recognises 0.9.* versions