### PR TITLE
Fix handling duplicates in IEM samplesheets which have no 'index' column

### DIFF
--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -1232,7 +1232,11 @@ class SampleSheet:
                 try:
                     index = "%s-%s" % (line['index'],line['index2'])
                 except KeyError:
-                    index = line['index']
+                    try:
+                        index = line['index']
+                    except KeyError:
+                        # No index columns
+                        index = None
             try:
                 lane = line['Lane']
             except KeyError:

--- a/bcftbx/test/test_IlluminaData.py
+++ b/bcftbx/test/test_IlluminaData.py
@@ -948,6 +948,27 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 1,PJB1,PJB1-1579,,,N701,CGATGTAT ,N501,TCTTTCCC,PeterBriggs,
 1,PJB2,PJB2-1580,,,N702,TGACCAAT ,N502,TCTTTCCC,PeterBriggs,
 """
+        self.nextseq_no_index_columns = """
+[Header]
+IEMFileVersion,4
+Date,2/7/2017
+Workflow,GenerateFASTQ
+Application,NextSeq FASTQ Only
+Assay,Nextera XT
+Description,
+Chemistry,Default
+
+[Reads]
+26
+130
+
+[Settings]
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,Sample_Project,Description
+PJB1,,,,,
+"""
 
     def test_load_hiseq_sample_sheet(self):
         """SampleSheet: load a HiSEQ IEM-format sample sheet
@@ -1379,6 +1400,19 @@ This,isTheEnd
         # Fix and check again (should be none)
         iem.fix_duplicated_names()
         self.assertEqual(iem.duplicated_names,[])
+    def test_duplicates_in_iem_format_no_index_columns(self):
+        """
+        SampleSheet: check duplicated names in IEM sample sheet (no index cols)
+
+        """
+        # Set up
+        iem = SampleSheet(fp=cStringIO.StringIO(
+            self.nextseq_no_index_columns))
+        # Shouldn't find any duplicates
+        self.assertEqual(len(iem.duplicated_names),0)
+        # Fix and check again (should have no change)
+        iem.fix_duplicated_names()
+        self.assertEqual(len(iem.duplicated_names),0)
     def test_illegal_names_in_iem_format(self):
         """
         SampleSheet: check for illegal characters in IEM sample sheet


### PR DESCRIPTION
PR which fixes the broken handling of duplicates for IEM samplesheets which don't have an `index` column in the `[Data]` section.

The `bcl2fastq` 2.17 documentation is ambiguous about whether the `index` column is obligatory, but in practice it seems that it can be omitted for situations where there is only one sample (when essentially it's the same as having an empty `index`).