### PR TITLE
Add support for equality operator (==) to FastqRead class

### DIFF
--- a/bcftbx/FASTQFile.py
+++ b/bcftbx/FASTQFile.py
@@ -251,6 +251,9 @@ class FastqRead:
                           self.optid,
                           self.quality))
 
+    def __eq__(self,other):
+        return (str(self) == str(other))
+
 class SequenceIdentifier:
     """Class to store/manipulate sequence identifier information from a FASTQ record
 

--- a/bcftbx/test/test_FASTQFile.py
+++ b/bcftbx/test/test_FASTQFile.py
@@ -101,6 +101,25 @@ class TestFastqRead(unittest.TestCase):
                          "BBA!>AA,B>;;=A%39%B8====>0?-?%9A2<)3?(4*36%A%4&+9%")
         self.assertTrue(read.is_colorspace)
 
+    def test_equality(self):
+        """Check FastqRead handles equality operator ('==')
+        """
+        readn1_data = """@73D9FA:3:FC:1:1:7507:1000 1:N:0:
+NACAACCTGATTAGCGGCGTTGACAGATGTATCCAT
++
+#))))55445@@@@@C@@@@@@@@@:::::<<:::<"""
+        readn1 = FastqRead(*readn1_data.split('\n'))
+        readn2 = FastqRead(*readn1_data.split('\n'))
+        readn3_data = """@73D9FA:3:FC:1:1:7507:1000 2:N:0:
+NACAACCTGATTAGCGGCGTTGACAGATGTATCCAT
++
+#))))55445@@@@@C@@@@@@@@@:::::<<:::<"""
+        readn3 = FastqRead(*readn3_data.split('\n'))
+        self.assertTrue(readn1 == readn2)
+        self.assertTrue(readn1 == readn1_data)
+        self.assertFalse(readn1 == readn3)
+        self.assertFalse(readn1 == readn3_data)
+
 class TestSequenceIdentifier(unittest.TestCase):
     """Tests of the SequenceIdentifier class
     """


### PR DESCRIPTION
PR that enables the use of the equality operator for `FastqRead` objects, so that two reads can be compared.