### PR TITLE
WIP Explicitly set exit status for terminated jobs in GEJobRunner

### DIFF
--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -493,6 +493,7 @@ class GEJobRunner(BaseJobRunner):
         p.wait()
         message = p.stdout.read()
         logging.debug("qdel: %s" % message)
+        self.__exit_status[job_id] = -1
         return True
 
     def logFile(self,job_id):


### PR DESCRIPTION
WIP PR which explicitly sets the exit status for terminated jobs in the `GEJobRunner` class, with the intention of avoiding pointless multiple calls to `qacct` when trying to fetch the exit status later on.