### PR TITLE
Fix FastqIterator and FastqRead classes to handle "empty" sequences

### DIFF
--- a/bcftbx/FASTQFile.py
+++ b/bcftbx/FASTQFile.py
@@ -213,7 +213,10 @@ class FastqRead:
             return self._maxqual
         except AttributeError:
             # Compute, store and return
-            self._maxqual = max(self.quality)
+            if self.quality:
+                self._maxqual = max(self.quality)
+            else:
+                self._maxqual = ''
         return self._maxqual
 
     @property
@@ -223,7 +226,10 @@ class FastqRead:
             return self._minqual
         except AttributeError:
             # Compute, store and return
-            self._minqual = min(self.quality)
+            if self.quality:
+                self._minqual = min(self.quality)
+            else:
+                self._minqual = ''
         return self._minqual
 
     @property

--- a/bcftbx/FASTQFile.py
+++ b/bcftbx/FASTQFile.py
@@ -120,8 +120,6 @@ class FastqIterator(Iterator):
                 raise StopIteration
             # Add to buffer and split into lines
             buf = buf + data
-            if buf[0] == '\n':
-                buf = buf[1:]
             if buf[-1] != '\n':
                 i = buf.rfind('\n')
                 if i == -1:

--- a/bcftbx/FASTQFile.py
+++ b/bcftbx/FASTQFile.py
@@ -77,7 +77,7 @@ class FastqIterator(Iterator):
 
     """
 
-    def __init__(self,fastq_file=None,fp=None):
+    def __init__(self,fastq_file=None,fp=None,bufsize=CHUNKSIZE):
         """Create a new FastqIterator
 
         The input FASTQ can be either a text file or a compressed (gzipped)
@@ -87,9 +87,12 @@ class FastqIterator(Iterator):
         Args:
            fastq_file: name of the FASTQ file to iterate through
            fp: file-like object opened for reading
+           bufsize: optional; integer specifying number of bytes to
+             read as a single 'chunk' from disk
 
         """
         self.__fastq_file = fastq_file
+        self.__bufsize = bufsize
         if fp is None:
             self.__fp = get_fastq_file_handle(self.__fastq_file)
         else:
@@ -105,10 +108,11 @@ class FastqIterator(Iterator):
         lines = self._lines
         buf = self._buf
         ip = self._ip
+        bufsize = self.__bufsize
         # Do we already have a read to return?
         while len(lines) < 4:
             # Fetch more data
-            data = self.__fp.read(CHUNKSIZE)
+            data = self.__fp.read(bufsize)
             if not data:
                 # Reached EOF
                 if self.__fastq_file is None:


### PR DESCRIPTION
PR to fix the `FastqIterator` and `FastqRead` classes in `bcftbx/FASTQFile.py` to deal with Fastq files that contain reads with "empty" (i.e. zero-length) sequences e.g.:

    1 |@73D9FA:3:FC:1:1:7488:1000 1:N:0:
    2 |
    3 |+
    4 |

Leaving aside the issue of whether or not these are valid Fastq read records, in practice they can be produced e.g. by `cutadapt` if (say) a read starts with adapter sequence that is being trimmed off.

In most cases `FastqIterator` could already handle these reads, however there is an edge case (related to the buffered approach of reading in the data from file) which meant that it was possible for a line to be 'dropped', resulting in incorrect read data. This PR adds a test for this edge case and fixes the issue.