### PR TITLE
Fix IlluminaData for bcl2fastq2 output where Fastqs are in subdirs with same name as sample

### DIFF
--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -547,6 +547,15 @@ class IlluminaProject:
                         fqs = filter(lambda f:
                                      f.startswith('%s/' % sample_name),
                                      fastqs)
+                    else:
+                        # Do fastqs have a leading subdir?
+                        leading_dir = list(set([os.path.dirname(fq)
+                                                for fq in fqs]))
+                        if len(leading_dir) == 1:
+                            # Same leading subdir for all fastqs
+                            # Update the sample dir
+                            sample_dirn = os.path.join(self.dirn,
+                                                       leading_dir[0])
                 else:
                     # Handle 'undetermined' data
                     try:

--- a/bcftbx/mock.py
+++ b/bcftbx/mock.py
@@ -1109,6 +1109,7 @@ class MockIlluminaData:
                 project_dirn = os.path.join(self.unaligned_dir,project_name)
             bcftbx.utils.mkdir(project_dirn)
             for sample_name in self.__projects[project_name]:
+                fastqs = []
                 for fastq in self.__projects[project_name][sample_name]:
                     # Check if sample name matches that for fastq
                     fq_sample_name = IlluminaFastq(fastq).sample_name
@@ -1119,9 +1120,17 @@ class MockIlluminaData:
                         bcftbx.utils.mkdir(sample_dirn)
                     else:
                         sample_dirn = project_dirn
-                    fq = os.path.join(sample_dirn,fastq)
+                    # Check for leading directory on fastq name
+                    if os.path.dirname(fastq):
+                        leading_dir = os.path.join(sample_dirn,
+                                                   os.path.dirname(fastq))
+                        bcftbx.utils.mkdir(leading_dir)
                     # "Touch" the file (i.e. creates an empty file)
+                    fq = os.path.join(sample_dirn,fastq)
                     open(fq,'wb+').close()
+                    fastqs.append(os.path.basename(fastq))
+                # Update the list of fastqs
+                self.__projects[project_name][sample_name] = fastqs
             # Add 'Reports' and 'Stats' directories
             for name in ('Reports','Stats',):
                 dirn = os.path.join(self.unaligned_dir,name)

--- a/bcftbx/test/test_IlluminaData.py
+++ b/bcftbx/test/test_IlluminaData.py
@@ -496,6 +496,27 @@ class TestIlluminaDataForBcl2fastq2SpecialCases(BaseTestIlluminaData):
         except Exception:
             pass
 
+    def makeMockIlluminaDataSampleDirs(self):
+        # Create initial mock dir
+        mock_illumina_data = MockIlluminaData('test.MockIlluminaData',
+                                              'bcl2fastq2',
+                                              paired_end=True,
+                                              top_dir=self.top_dir)
+        lanes=(1,2,)
+        mock_illumina_data.add_fastq_batch('AB','AB1','AB1/AB1_S1',
+                                           lanes=lanes)
+        mock_illumina_data.add_fastq_batch('AB','AB2','AB2/AB2_S2',
+                                           lanes=lanes)
+        mock_illumina_data.add_fastq_batch('CDE','CDE3','CDE3/CDE3_S3',
+                                           lanes=lanes)
+        mock_illumina_data.add_fastq_batch('CDE','CDE4','CDE4/CDE4_S4',
+                                           lanes=lanes)
+        # Undetermined reads
+        mock_illumina_data.add_undetermined(lanes=lanes)
+        # Create and finish
+        self.mock_illumina_data = mock_illumina_data
+        self.mock_illumina_data.create()
+
     def makeMockIlluminaDataIdsDiffer(self,ids_differ_for_all=False):
         # Create initial mock dir
         mock_illumina_data = MockIlluminaData('test.MockIlluminaData',
@@ -592,6 +613,15 @@ class TestIlluminaDataForBcl2fastq2SpecialCases(BaseTestIlluminaData):
 
         """
         self.makeMockIlluminaDataIdsDiffer(ids_differ_for_all=False)
+        illumina_data = IlluminaData(self.mock_illumina_data.dirn)
+        self.assertIlluminaData(illumina_data,self.mock_illumina_data)
+        self.assertEqual(illumina_data.format,'bcl2fastq2')
+        self.assertEqual(illumina_data.lanes,[1,2])
+
+    def test_illumina_data_sample_subdirs(self):
+        """Read bcl2fastq output when samples are in subdirs
+        """
+        self.makeMockIlluminaDataSampleDirs()
         illumina_data = IlluminaData(self.mock_illumina_data.dirn)
         self.assertIlluminaData(illumina_data,self.mock_illumina_data)
         self.assertEqual(illumina_data.format,'bcl2fastq2')


### PR DESCRIPTION
PR attempts to fix an edge case for the `IlluminaData` class when there is `bcl2fastqv2`-style output with Fastq files that are in subdirectories which are called the same name as the sample.

For example: for a Fastq file in project `AB` and sample `AB1`:

    bcl2fastq/AB/AB1/AB1_S1_L001_R1_001.fastq.gz

According to my understanding of the `bcl2fastq` v2 manual, it shouldn't be possible to generate this arrangement as the "sample"-level subdirectories (`AB1` in the example above) should only be created when the name differs from the ID as supplied in the sample sheet.

However as this case has been encountered in output from 10xGenomics `cellranger mkfastq` command, this PR updates the relevant code to be able to handle the situation.