### PR TITLE
Update QC pipeline infrastructure and scripts to handle .fq(.gz) files

### DIFF
--- a/QC-pipeline/fastq_screen.sh
+++ b/QC-pipeline/fastq_screen.sh
@@ -59,6 +59,7 @@ fastq=`basename $1`
 # Strip "fastq(.gz)" extension
 fastq_base=${fastq%.gz}
 fastq_base=${fastq_base%.fastq}
+fastq_base=${fastq_base%.fq}
 #
 # Get the data directory i.e. location of the input file
 datadir=`dirname $1`

--- a/QC-pipeline/illumina_qc.sh
+++ b/QC-pipeline/illumina_qc.sh
@@ -209,7 +209,7 @@ fi
 # Report program paths and versions
 #############################################
 #
-program_info=qc/$fastq_base.$qc.programs
+program_info=qc/${fastq_base%%.fq}.$qc.programs
 echo "# Program versions and paths used for $fastq_base:" > $program_info
 report_program_info $FASTQ_SCREEN >> $program_info
 report_program_info $FASTQC >> $program_info
@@ -243,7 +243,8 @@ fi
 run_fastq_screen --threads $threads --subset $subset $FASTQ
 #
 # Run FASTQC
-if [ ! -d qc/${fastq_base}_fastqc ] || [ ! -f qc/${fastq_base}_fastqc.zip ] ; then
+fastqc_base=${fastq_base%%.fq}_fastqc
+if [ ! -d qc/${fastqc_base} ] || [ ! -f qc/${fastqc_base}.zip ] ; then
     fastqc_cmd="${FASTQC} --outdir qc --nogroup --extract --threads $threads"
     if [ ! -z "$FASTQC_CONTAMINANTS_FILE" ] ; then
 	# Nb avoid -c even though this should be valid it seems to
@@ -256,8 +257,16 @@ if [ ! -d qc/${fastq_base}_fastqc ] || [ ! -f qc/${fastq_base}_fastqc.zip ] ; th
     if [ $? -ne 0 ] ; then
 	echo FASTQC failed >&2
     fi
+    # Deal with non-standard .fq extension
+    fastqc_out=${fastq_base}_fastqc
+    if [ "$fastqc_out" != "$fastqc_base" ] ; then
+	echo "Moving $fastqc_out to $fastqc_base..."
+	/bin/mv qc/$fastqc_out qc/$fastqc_base
+	/bin/mv qc/$fastqc_out.html qc/$fastqc_base.html
+	/bin/mv qc/$fastqc_out.zip qc/$fastqc_base.zip
+    fi
 else
-    echo "FastQC output already exists: qc/${fastq_base}_fastqc(.zip)"
+    echo "FastQC output already exists: qc/${fastqc_base}(.zip)"
 fi
 #
 # Update permissions and group (if specified)

--- a/bcftbx/Pipeline.py
+++ b/bcftbx/Pipeline.py
@@ -711,12 +711,12 @@ def GetFastqFiles(dirn,pattern=None,file_list=None):
     # Regular expression pattern
     if pattern is not None:
         regex = re.compile(pattern)
-    # Look for csfasta and matching qual files
+    # Look for Fastq files
     for filen in all_files:
         logging.debug("Examining file %s" % filen)
         root = os.path.splitext(filen)[0]
         ext = os.path.splitext(filen)[1]
-        if ext == ".fastq":
+        if ext in (".fastq",".fq"):
             # If a regex pattern is specified then also filter on it
             if pattern is None or regex.search(root):
                 data_files.append((filen,))
@@ -762,7 +762,7 @@ def GetFastqGzFiles(dirn,pattern=None,file_list=None):
         if filen.split('.')[-1] == "gz":
             # Ends with gz
             try:
-                if filen.split('.')[-2] == "fastq":
+                if filen.split('.')[-2] in ("fastq","fq"):
                     # If a regex pattern is specified then also filter on it
                     if pattern is None or regex.search(filen.split('.')[-3]):
                         data_files.append((filen,))

--- a/bcftbx/qc/report.py
+++ b/bcftbx/qc/report.py
@@ -1174,7 +1174,7 @@ def strip_ngs_extensions(name):
     for ext in ('.gz','.bz2'):
         strip_name = utils.strip_ext(strip_name,ext)
     # Then remove bioinf extensions
-    for ext in ('.fastq','.csfasta','.qual'):
+    for ext in ('.fastq','.fq','.csfasta','.qual'):
         strip_name = utils.strip_ext(strip_name,ext)
     return strip_name
 

--- a/bcftbx/qc/test/test_report.py
+++ b/bcftbx/qc/test/test_report.py
@@ -28,8 +28,12 @@ class TestStripNGSExtensions(unittest.TestCase):
         self.assertEqual(strip_ngs_extensions("ED2_QV.qual"),"ED2_QV")
     def test_strip_ngs_extensions_fastq(self):
         self.assertEqual(strip_ngs_extensions("ED2.fastq"),"ED2")
+    def test_strip_ngs_extensions_fq(self):
+        self.assertEqual(strip_ngs_extensions("ED2.fq"),"ED2")
     def test_strip_ngs_extensions_fastq_gz(self):
         self.assertEqual(strip_ngs_extensions("ED2.fastq.gz"),"ED2")
+    def test_strip_ngs_extensions_fq_gz(self):
+        self.assertEqual(strip_ngs_extensions("ED2.fq.gz"),"ED2")
     def test_strip_ngs_extensions_dots_in_name(self):
         self.assertEqual(strip_ngs_extensions("ED2.1.fastq"),"ED2.1")
         self.assertEqual(strip_ngs_extensions("ED2.1.fastq.gz"),"ED2.1")

--- a/bcftbx/test/test_Pipeline.py
+++ b/bcftbx/test/test_Pipeline.py
@@ -426,6 +426,24 @@ class TestGetFastqFiles(unittest.TestCase):
         for fq1,fq2 in zip(expected,fastqs):
             self.assertEqual(fq1,fq2)
 
+    def test_get_fastq_files_fq_extension(self):
+        file_list = ['sample1.fq.gz',
+                     'sample2.fq.gz',
+                     'sample3_R1.fq',
+                     'sample3_R2.fq',
+                     'sample4_R1.fq',
+                     'sample4_R2.fq',
+                     'out.log',
+                     'README']
+        expected = [('sample3_R1.fq',),
+                    ('sample3_R2.fq',),
+                    ('sample4_R1.fq',),
+                    ('sample4_R2.fq',)]
+        fastqs = GetFastqFiles('test',file_list=file_list)
+        self.assertEqual(len(expected),len(fastqs))
+        for fq1,fq2 in zip(expected,fastqs):
+            self.assertEqual(fq1,fq2)
+
 class TestGetFastqGzFiles(unittest.TestCase):
     """Unit tests for GetFastqGzFiles function
 
@@ -462,6 +480,25 @@ class TestGetFastqGzFiles(unittest.TestCase):
         self.assertEqual(len(expected),len(fastqgzs))
         for fq1,fq2 in zip(expected,fastqgzs):
             self.assertEqual(fq1,fq2)
+
+    def test_get_fastq_gz_files_fq_extension(self):
+        file_list = ['sample1_R1.fq.gz',
+                     'sample1_R2.fq.gz',
+                     'sample2_R1.fq.gz',
+                     'sample2_R2.fq.gz',
+                     'sample3.fq',
+                     'sample4.fq',
+                     'out.log',
+                     'README']
+        expected = [('sample1_R1.fq.gz',),
+                    ('sample1_R2.fq.gz',),
+                    ('sample2_R1.fq.gz',),
+                    ('sample2_R2.fq.gz',)]
+        fastqgzs = GetFastqGzFiles('test',file_list=file_list)
+        self.assertEqual(len(expected),len(fastqgzs))
+        for fq1,fq2 in zip(expected,fastqgzs):
+            self.assertEqual(fq1,fq2)
+        
 
 #######################################################################
 # Main program


### PR DESCRIPTION
PR to update the QC pipeline and scripts to handle `.fq[.gz]` Fastq files:

* Update `GetFastqFiles` and `GetFastqGzFiles` functions in `bcftbx/Pipeline.py` to pick up Fastq files with `.fq[.gz]` extensions
* Update `strip_ngs_extensions` function in `bcftbx/qc/report.py` to also remove `.fq` extensions
* Update the `illumina_qc.sh` and `fastq_screen.sh` scripts in `QC-pipeline` to handle outputs for files with `.fq` extension