### PR TITLE
Fix failing chmod/chgrp operations in illumina_qc.sh script

### DIFF
--- a/NGS-general/uncompress_fastqgz.sh
+++ b/NGS-general/uncompress_fastqgz.sh
@@ -97,7 +97,7 @@ else
 fi
 #
 # Update permissions and group (if specified)
-set_permissions_and_group "$SET_PERMISSIONS" "$SET_GROUP"
+set_permissions_and_group -R --quiet "$SET_PERMISSIONS" "$SET_GROUP"
 #
 echo UNCOMPRESS FASTQ.GZ completed: `date`
 exit

--- a/QC-pipeline/fastq_screen.sh
+++ b/QC-pipeline/fastq_screen.sh
@@ -50,16 +50,18 @@ while [ $# -gt 1 ] ; do
     shift
 done
 #
+# Set up environment
+export PATH=$(dirname $0)/../share:${PATH}
+. bcftbx.functions.sh
+. bcftbx.ngs_utils.sh
+. bcftbx.versions.sh
+import_qc_settings
+#
 # Set umask to allow group read-write on all new files etc
 umask 0002
 #
 # Get the input file
 fastq=`basename $1`
-#
-# Strip "fastq(.gz)" extension
-fastq_base=${fastq%.gz}
-fastq_base=${fastq_base%.fastq}
-fastq_base=${fastq_base%.fq}
 #
 # Get the data directory i.e. location of the input file
 datadir=`dirname $1`
@@ -67,12 +69,8 @@ if [ "$datadir" == "." ] ; then
     datadir=`pwd`
 fi
 #
-# Set up environment
-export PATH=$(dirname $0)/../share:${PATH}
-. bcftbx.functions.sh
-. bcftbx.ngs_utils.sh
-. bcftbx.versions.sh
-import_qc_settings
+# Strip "fastq(.gz)" extension
+fastq_base=$(get_fastq_basename $fastq)
 #
 # Set the programs
 # Override these defaults by setting them in qc.setup

--- a/QC-pipeline/illumina_qc.sh
+++ b/QC-pipeline/illumina_qc.sh
@@ -269,14 +269,17 @@ else
     echo "FastQC output already exists: qc/${fastqc_base}(.zip)"
 fi
 #
-# Update permissions and group (if specified)
-set_permissions_and_group "$SET_PERMISSIONS" "$SET_GROUP"
-#
 # Remove local temp
 if [ -d $local_tmp ] ; then
     echo "Removing local tmp dir $local_tmp"
     /bin/rm -rf $local_tmp
 fi
+#
+# Update permissions and group (if specified)
+set_permissions_and_group "$SET_PERMISSIONS" "$SET_GROUP" qc
+set_permissions_and_group "$SET_PERMISSIONS" "$SET_GROUP" "$program_info"
+set_permissions_and_group "$SET_PERMISSIONS" "$SET_GROUP" "qc/$(get_fastq_basename $FASTQ)_*_screen.*"
+set_permissions_and_group -R "$SET_PERMISSIONS" "$SET_GROUP" "qc/${fastqc_base}*"
 #
 echo ILLUMINA QC pipeline completed: `date`
 exit

--- a/QC-pipeline/solid_qc.sh
+++ b/QC-pipeline/solid_qc.sh
@@ -256,7 +256,7 @@ fi
 cd ..
 #
 # Set permissions and group (if specified)
-set_permissions_and_group "$SET_PERMISSIONS" "$SET_GROUP"
+set_permissions_and_group -R --quiet "$SET_PERMISSIONS" "$SET_GROUP"
 #
 echo SOLiD QC pipeline completed: `date`
 exit

--- a/share/bcftbx.functions.sh
+++ b/share/bcftbx.functions.sh
@@ -181,16 +181,49 @@ function make_temp() {
 #
 # The new group and permissions mode can be empty strings if no
 # change is required
+#
+# If target is not specified then defaults to PWD/*
+#
+# Supports the following options for chmod/chgrp:
+#
+# -R: perform operations recursively
+#
+# --quiet: suppress most error messages
+#
+# Usage: set_permissions_and_group [-R] [--quiet] PERMS GROUP [TARGET]
 function set_permissions_and_group() {
+    # Process the arguments
+    local options=
+    while [ ! -z $1 ] ; do
+	case "$1" in
+	    -R)
+		options="$options -R"
+		;;
+	    --quiet)
+	        options="$options --quiet"
+		;;
+	    *)
+		# Assume end of options
+		break
+		;;
+	esac
+	shift
+    done
     local permissions_mode=$1
     local new_group=$2
+    local target=$3
+    if [ ! -z "$dir" ] ; then
+	target="$(pwd)/*"
+    else
+	target=$(abs_path $target)
+    fi
     if [ ! -z "$permissions_mode" ] ; then
-	echo Recursively setting permissions to $permissions_mode
-	chmod -R --quiet $permissions_mode *
+	echo Setting permissions to $permissions_mode for $target
+	chmod $options $permissions_mode $target
     fi
     if [ ! -z "$new_group" ] ; then
-	echo Recursively setting group to $new_group
-	chgrp -R --quiet $new_group *
+	echo Setting group to $new_group for $target
+	chgrp $options $new_group $target
     fi
 }
 #

--- a/share/bcftbx.ngs_utils.sh
+++ b/share/bcftbx.ngs_utils.sh
@@ -38,6 +38,21 @@ function import_qc_settings() {
     fi
 }
 #
+# get_fastq_basename: strip fastq extension from filename
+#
+# Removes the leading directory and the ".fastq(.gz)"/".fq(.gz)" file
+# extensions from the supplied file name.
+#
+# Usage: get_fastq_basename FASTQ
+#
+function get_fastq_basename() {
+    local fastq_base=$(basename $1)
+    fastq_base=${fastq_base%.gz}
+    fastq_base=${fastq_base%.fastq}
+    fastq_base=${fastq_base%.fq}
+    echo $fastq_base
+}
+#
 # run_solid2fastq: create fastq file
 #
 # Provide names of csfasta and qual files (can include leading paths)


### PR DESCRIPTION
PR to address issue #42 where the `illumina_qc.sh` script would sometimes fail to complete, leaving behind the temporary directories used to run the QC in.

The problem appears to be a combination of factors:

* The `set_permissions_and_group` function (used to to invoke `chmod` and `chgrp` from `illumina_qc.sh`) was being run on all files and directories in the current directory (i.e. not just the `qc` dir)
* When `illumina_qc.sh` was run multiple times simultaneously in the same directory (typical when QC'ing a set of Fastqs from a sequencing run), these operations invoked in one run might then try to change the attributes on the temporary files from another while those files were being removed. In this case the operations would fail and terminate the script.

The PR makes changes to `set_permissions_and_group` and the `illumina_qc.sh` script to try and avoid this situation occurring: temporary files are removed before the `chmod`/`chgrp` operations, and the attribute reset is limited to just the appropriate subset of files from the script.

There are also changes to `solid_qc.sh` and `uncompress_fastqgz.sh`, to ensure that the behaviour of their `set_permissions_and_group` calls is unchanged.

There is a change to `fastq_screen.sh` to abstract Fastq extension stripping functionality into a function in `bcftbx.ngs_utils`, which is now also used in `illumina_qc.sh` (to help with targeting the output files for attribute reset).