### PR TITLE
Reduce the default subset size used for fastq_screen in QC pipeline

### DIFF
--- a/QC-pipeline/fastq_screen.sh
+++ b/QC-pipeline/fastq_screen.sh
@@ -15,7 +15,7 @@ function usage() {
     echo "will be created if not found)"
     echo ""
     echo "Options:"
-    echo "  --subset N: use subset of N reads (default 1000000, 0=use all reads)"
+    echo "  --subset N: use subset of N reads (default 100000, 0=use all reads)"
     echo "  --color: use colorspace bowtie indexes (SOLiD data)"
     echo "  --threads N: use N threads to run fastq_screen (default is 1)"
     echo "  --qc_dir DIR: output QC to DIR (default is 'qc')"
@@ -29,7 +29,7 @@ fi
 options=
 color=
 threads=1
-subset=1000000
+subset=100000
 qc_dir=qc
 while [ $# -gt 1 ] ; do
     case "$1" in

--- a/QC-pipeline/illumina_qc.sh
+++ b/QC-pipeline/illumina_qc.sh
@@ -34,7 +34,7 @@ function usage() {
     echo "                available to the script (default"
     echo "                is N=1)"
     echo "  --subset N    number of reads to use in"
-    echo "                fastq_screen (default N=1000000,"
+    echo "                fastq_screen (default N=100000,"
     echo "                N=0 to use all reads)"
     echo "  --qc_dir DIR  output QC to DIR (default 'qc')"
 }
@@ -100,7 +100,7 @@ fi
 # Check for additional options
 do_ungzip=no
 threads=1
-subset=1000000
+subset=100000
 qc_dir=qc
 while [ ! -z "$2" ] ; do
     case "$2" in


### PR DESCRIPTION
PR to reduce the default subset size used in `fastq_screen.sh` and `illumina_qc.sh`, to bring it into line with the default subset the `fastq_screen` program itself uses (from 1000000 to 100000).