### PR TITLE
Move generic file reading functions from 'extract_reads.py' into bcftbx library

### DIFF
--- a/NGS-general/extract_reads.py
+++ b/NGS-general/extract_reads.py
@@ -32,7 +32,9 @@ import gzip
 import optparse
 import random
 import re
-from bcftbx.utils import getlines
+from bcftbx.ngsutils import getreads
+from bcftbx.ngsutils import getreads_subset
+from bcftbx.ngsutils import getreads_regex
 
 #######################################################################
 # Module metadata
@@ -44,136 +46,6 @@ __description__ = """Extract subsets of reads from each of the
 supplied files according to specified criteria (e.g. random,
 matching a pattern etc). Input files can be any mixture of FASTQ
 (.fastq, .fq), CSFASTA (.csfasta) and QUAL (.qual)."""
-
-#######################################################################
-# Functions
-#######################################################################
-
-def getreads(filen):
-    """
-    Fetch reads from a file and return them one by one
-
-    This generator function iterates through a
-    sequence file (for example fastq), and yields read
-    records as a list of lines.
-
-    The file can be gzipped; this function should handle
-    this invisibly provided that the file extension is
-    '.gz'.
-
-    Arguments:
-      filen (str): path of the file to fetch reads from
-
-    Yields:
-      List: next read record from the file, as a list
-        of lines.
-
-    """
-    size = read_size(filen)
-    read = []
-    for i,line in enumerate(getlines(filen),start=1):
-        read.append(line)
-        if i%size == 0:
-            yield read
-            read = []
-    if read:
-        raise Exception("Incomplete read found at file end: %s"
-                        % read)
-
-def getreads_subset(filen,indices):
-    """
-    Fetch subset of reads from a file
-
-    This generator function iterates through a
-    sequence file (for example fastq), and yields a subset
-    of read records. Each read is returned as a list of
-    lines.
-
-    The subset compromises of reads at the index positions
-    specified by the list of indices, with index 0 being the
-    first read in the file.
-
-    The file can be gzipped; this function should handle
-    this invisibly provided that the file extension is
-    '.gz'.
-
-    Arguments:
-      filen (str): path of the file to fetch reads from
-      indices (list): list of read indices to return
-
-    Yields:
-      List: next read record from the file, as a list
-        of lines.
-
-    """
-    indices_ = [int(i) for i in indices]
-    indices_.sort()
-    i = 0
-    next_idx = indices_[i]
-    for idx,read in enumerate(getreads(filen)):
-        if idx == next_idx:
-            #print "Extracting read %s" % idx
-            #print read
-            yield read
-            try:
-                i += 1
-                next_idx = indices_[i]
-            except IndexError:
-                # No more reads to extract
-                return
-    raise Exception("One or more requested read indices out of range")
-
-def getreads_regex(filen,pattern):
-    """
-    Fetch subset of reads from a file
-
-    This generator function iterates through a
-    sequence file (for example fastq), and yields a subset
-    of read records. Each read is returned as a list of
-    lines.
-
-    The subset compromises of reads which match the
-    supplied regular expression.
-
-    The file can be gzipped; this function should handle
-    this invisibly provided that the file extension is
-    '.gz'.
-
-    Arguments:
-      filen (str): path of the file to fetch reads from
-      pattern (list): Python regular expression pattern
-
-    Yields:
-      List: next read record from the file, as a list
-        of lines.
-
-    """
-    regex = re.compile(pattern)
-    for read in getreads(filen):
-        if regex.search(''.join(read)):
-            yield read
-
-def read_size(filen):
-    """
-    Return size of read based on file type
-
-    Arguments:
-      filen (str): name of file
-
-    Returns:
-      int: number of lines that each read
-        record occupies in this type of file
-
-    """
-    # Strip trailing .gz
-    if filen.endswith('.gz'):
-        filen = filen[:-3]
-    # Identify file type from extension
-    ext = filen.split('.')[-1]
-    if ext in ('fastq','fq'):
-        return 4
-    elif ext in ('csfasta','qual'):
-        return 2
 
 #######################################################################
 # Main

--- a/NGS-general/extract_reads.py
+++ b/NGS-general/extract_reads.py
@@ -32,14 +32,13 @@ import gzip
 import optparse
 import random
 import re
+from bcftbx.utils import getlines
 
 #######################################################################
 # Module metadata
 #######################################################################
 
 __version__ = "0.2.0"
-
-CHUNKSIZE = 102400
 
 __description__ = """Extract subsets of reads from each of the
 supplied files according to specified criteria (e.g. random,
@@ -49,67 +48,6 @@ matching a pattern etc). Input files can be any mixture of FASTQ
 #######################################################################
 # Functions
 #######################################################################
-
-def getlines(filen):
-    """
-    Fetch lines from a file and return them one by one
-
-    This generator function tries to implement an efficient
-    method of reading lines sequentially from a file, by
-    minimising the number of reads from the file and
-    performing the line splitting in memory. It attempts
-    to replicate the idiom:
-
-    >>> for line in open(filen):
-    >>> ...
-
-    using:
-
-    >>> for line in getlines(filen):
-    >>> ...
-
-    The file can be gzipped; this function should handle
-    this invisibly provided that the file extension is
-    '.gz'.
-
-    Arguments:
-      filen (str): path of the file to read lines from
-
-    Yields:
-      String: next line of text from the file, with any
-        newline character removed.
-    
-    """
-    if filen.split('.')[-1] == 'gz':
-        fp = gzip.open(filen,'rb')
-    else:
-        fp = open(filen,'rb')
-    # Read in data in chunks
-    buf = ''
-    lines = []
-    while True:
-        # Grab a chunk of data
-        data = fp.read(CHUNKSIZE)
-        # Check for EOF
-        if not data:
-            break
-        # Add to buffer and split into lines
-        buf = buf + data
-        if buf[0] == '\n':
-            buf = buf[1:]
-        if buf[-1] != '\n':
-            i = buf.rfind('\n')
-            if i == -1:
-                continue
-            else:
-                lines = buf[:i].split('\n')
-                buf = buf[i+1:]
-        else:
-            lines = buf[:-1].split('\n')
-            buf = ''
-        # Return the lines one at a time
-        for line in lines:
-            yield line
 
 def getreads(filen):
     """

--- a/bcftbx/ngsutils.py
+++ b/bcftbx/ngsutils.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+#
+#     utils.py: utility classes & functions specific to NGS applications
+#     Copyright (C) University of Manchester 2017 Peter Briggs
+#
+########################################################################
+#
+# ngsutils.py
+#
+#########################################################################
+
+"""
+ngsutils
+
+Utility classes and functions specific to NGS applications.
+
+- getreads
+- getreads_subset
+- getreads_regexp
+- read_size
+
+"""
+
+#######################################################################
+# Imports
+#######################################################################
+
+import re
+from .utils import getlines
+
+#######################################################################
+# Functions
+#######################################################################
+
+def getreads(filen):
+    """
+    Fetch reads from a file and return them one by one
+
+    This generator function iterates through a
+    sequence file (for example fastq), and yields read
+    records as a list of lines.
+
+    The file can be gzipped; this function should handle
+    this invisibly provided that the file extension is
+    '.gz'.
+
+    Lines starting with '#' at the start of the file will
+    be treated as comments and ignored. Lines starting
+    with '#' which occur in the body of the file (i.e.
+    after one or more lines of data) will be treated as
+    data.
+
+    Arguments:
+      filen (str): path of the file to fetch reads from
+
+    Yields:
+      List: next read record from the file, as a list
+        of lines.
+    """
+    header = True
+    size = read_size(filen)
+    read = []
+    for i,line in enumerate(getlines(filen),start=1):
+        if header:
+            if line.startswith('#'):
+                continue
+            else:
+                header = False
+        read.append(line)
+        if i%size == 0:
+            yield read
+            read = []
+    if read:
+        raise Exception("Incomplete read found at file end: %s"
+                        % read)
+
+def getreads_subset(filen,indices):
+    """
+    Fetch subset of reads from a file
+
+    This generator function iterates through a
+    sequence file (for example fastq), and yields a subset
+    of read records. Each read is returned as a list of
+    lines.
+
+    The subset compromises of reads at the index positions
+    specified by the list of indices, with index 0 being the
+    first read in the file.
+
+    The file can be gzipped; this function should handle
+    this invisibly provided that the file extension is
+    '.gz'.
+
+    Arguments:
+      filen (str): path of the file to fetch reads from
+      indices (list): list of read indices to return
+
+    Yields:
+      List: next read record from the file, as a list
+        of lines.
+    """
+    indices_ = [int(i) for i in indices]
+    indices_.sort()
+    i = 0
+    next_idx = indices_[i]
+    for idx,read in enumerate(getreads(filen)):
+        if idx == next_idx:
+            #print "Extracting read %s" % idx
+            #print read
+            yield read
+            try:
+                i += 1
+                next_idx = indices_[i]
+            except IndexError:
+                # No more reads to extract
+                return
+    raise Exception("One or more requested read indices out of range")
+
+def getreads_regex(filen,pattern):
+    """
+    Fetch subset of reads from a file
+
+    This generator function iterates through a
+    sequence file (for example fastq), and yields a subset
+    of read records. Each read is returned as a list of
+    lines.
+
+    The subset compromises of reads which match the
+    supplied regular expression.
+
+    The file can be gzipped; this function should handle
+    this invisibly provided that the file extension is
+    '.gz'.
+
+    Arguments:
+      filen (str): path of the file to fetch reads from
+      pattern (list): Python regular expression pattern
+
+    Yields:
+      List: next read record from the file, as a list
+        of lines.
+    """
+    regex = re.compile(pattern)
+    for read in getreads(filen):
+        if regex.search(''.join(read)):
+            yield read
+
+def read_size(filen):
+    """
+    Return size of read based on file type
+
+    Arguments:
+      filen (str): name of file
+
+    Returns:
+      int: number of lines that each read
+        record occupies in this type of file
+    """
+    # Strip trailing .gz
+    if filen.endswith('.gz'):
+        filen = filen[:-3]
+    # Identify file type from extension
+    ext = filen.split('.')[-1]
+    if ext in ('fastq','fq'):
+        return 4
+    elif ext in ('csfasta','qual'):
+        return 2

--- a/bcftbx/ngsutils.py
+++ b/bcftbx/ngsutils.py
@@ -122,6 +122,8 @@ def getreads_subset(filen,indices):
     """
     indices_ = [int(i) for i in indices]
     indices_.sort()
+    if indices_[0] < 0:
+        raise Exception("One or more requested read indices out of range")
     i = 0
     next_idx = indices_[i]
     for idx,read in enumerate(getreads(filen)):

--- a/bcftbx/test/test_ngsutils.py
+++ b/bcftbx/test/test_ngsutils.py
@@ -154,10 +154,14 @@ AAF#FJJJJJJJJJJJ
             fp.write(self.example_fastq_data)
         # Attempt to get subset with indices outside the range
         # of reads
-        fastq_reads = getreads_subset(example_fastq,
-                                      indices=(-1,0))
-        fastq_reads = getreads_subset(example_fastq,
-                                      indices=(0,99999))
+        self.assertRaises(Exception,
+                          getreads_subset,
+                          example_fastq,
+                          indices=(-1,0))
+        self.assertRaises(Exception,
+                          getreads_subset,
+                          example_fastq,
+                          indices=(0,99999))
 
 class TestGetreadsRegexpFunction(unittest.TestCase):
     """Tests for the 'getreads_regex' function

--- a/bcftbx/test/test_ngsutils.py
+++ b/bcftbx/test/test_ngsutils.py
@@ -154,14 +154,22 @@ AAF#FJJJJJJJJJJJ
             fp.write(self.example_fastq_data)
         # Attempt to get subset with indices outside the range
         # of reads
-        self.assertRaises(Exception,
-                          getreads_subset,
-                          example_fastq,
-                          indices=(-1,0))
-        self.assertRaises(Exception,
-                          getreads_subset,
-                          example_fastq,
-                          indices=(0,99999))
+        # NB would prefer to use assertRaises, however we need to
+        # actually yeild the reads in order to raise the exceptions
+        try:
+            [r for r in getreads_subset(example_fastq,indices=(-1,0))]
+            failed = True
+        except Exception:
+            # This is expected, test passes
+            failed = False
+        self.assertFalse(failed,"Exception not raised")
+        try:
+            [r for r in getreads_subset(example_fastq,indices=(0,99))]
+            failed = True
+        except Exception:
+            # This is expected, test passes
+            failed = False
+        self.assertFalse(failed,"Exception not raised")
 
 class TestGetreadsRegexpFunction(unittest.TestCase):
     """Tests for the 'getreads_regex' function

--- a/bcftbx/test/test_ngsutils.py
+++ b/bcftbx/test/test_ngsutils.py
@@ -145,6 +145,19 @@ AAF#FJJJJJJJJJJJ
                            for i in (0,8)]
         for r1,r2 in zip(reference_reads,fastq_reads):
             self.assertEqual(r1,r2)
+    def test_getreads_subset_fastq_index_out_of_range(self):
+        """getreads: requesting non-existent read raises exception
+        """
+        # Make an example file
+        example_fastq = os.path.join(self.wd,"example.fastq")
+        with open(example_fastq,'w') as fp:
+            fp.write(self.example_fastq_data)
+        # Attempt to get subset with indices outside the range
+        # of reads
+        fastq_reads = getreads_subset(example_fastq,
+                                      indices=(-1,0))
+        fastq_reads = getreads_subset(example_fastq,
+                                      indices=(0,99999))
 
 class TestGetreadsRegexpFunction(unittest.TestCase):
     """Tests for the 'getreads_regex' function
@@ -180,48 +193,3 @@ AAF#FJJJJJJJJJJJ
                            for i in (0,)]
         for r1,r2 in zip(reference_reads,fastq_reads):
             self.assertEqual(r1,r2)
-
-class TestReadSizeFunction(unittest.TestCase):
-    """Tests for the 'read_size' function
-    """
-    def test_read_size_fastq(self):
-        """
-        read_size: check '.fastq' extension
-        """
-        self.assertEqual(read_size("test.fastq"),4)
-    def test_read_size_fastq_gz(self):
-        """
-        read_size: check '.fastq.gz' extension
-        """
-        self.assertEqual(read_size("test.fastq.gz"),4)
-    def test_read_size_fq(self):
-        """
-        read_size: check '.fq' extension
-        """
-        self.assertEqual(read_size("test.fq"),4)
-    def test_read_size_fq_gz(self):
-        """
-        read_size: check '.fq.gz' extension
-        """
-        self.assertEqual(read_size("test.fq.gz"),4)
-    def test_read_size_csfasta(self):
-        """
-        read_size: check '.csfasta' extension
-        """
-        self.assertEqual(read_size("test.csfasta"),2)
-    def test_read_size_csfasta_gz(self):
-        """
-        read_size: check '.csfasta.gz' extension
-        """
-        self.assertEqual(read_size("test.csfasta.gz"),2)
-    def test_read_size_qual(self):
-        """
-        read_size: check '.qual' extension
-        """
-        self.assertEqual(read_size("test.qual"),2)
-    def test_read_size_qual_gz(self):
-        """
-        read_size: check '.qual.gz' extension
-        """
-        self.assertEqual(read_size("test.qual.gz"),2)
-

--- a/bcftbx/test/test_ngsutils.py
+++ b/bcftbx/test/test_ngsutils.py
@@ -1,0 +1,227 @@
+#######################################################################
+# Tests for ngsutils.py module
+#######################################################################
+import unittest
+import os
+import tempfile
+import shutil
+import gzip
+from bcftbx.ngsutils import *
+
+class TestGetreadsFunction(unittest.TestCase):
+    """Tests for the 'getreads' function
+    """
+    def setUp(self):
+        self.wd = tempfile.mkdtemp()
+        self.example_fastq_data = """@K00311:43:HL3LWBBXX:8:1101:21440:1121 1:N:0:CNATGT
+GCCNGACAGCAGAAAT
++
+AAF#FJJJJJJJJJJJ
+@K00311:43:HL3LWBBXX:8:1101:21460:1121 1:N:0:CNATGT
+GGGNGTCATTGATCAT
++
+AAF#FJJJJJJJJJJJ
+@K00311:43:HL3LWBBXX:8:1101:21805:1121 1:N:0:CNATGT
+CCCNACCCTTGCCTAC
++
+AAF#FJJJJJJJJJJJ
+"""
+        self.example_csfasta_data = """# Cwd: /home/pipeline
+# Title: solid0127_20121204_FRAG_BC_Run_56_pool_LC_CK
+>1_51_38_F3
+T3..3.213.12211.01..000..111.0210202221221121011..0
+>1_51_301_F3
+T0..3.222.21233.00..022..110.0210022323223202211..2
+>1_52_339_F3
+T1.311202211102.331233332113.23332233002223222312.2
+"""
+        self.example_qual_data = """# Cwd: /home/pipeline
+# Title: solid0127_20121204_FRAG_BC_Run_56_pool_LC_CK
+>1_51_38_F3
+16 -1 -1 5 -1 24 15 12 -1 21 12 16 22 19 -1 26 13 -1 -1 4 21 4 -1 -1 4 7 9 -1 4 5 4 4 4 4 4 13 4 4 4 5 4 4 10 4 4 4 4 -1 -1 4 
+>1_51_301_F3
+22 -1 -1 4 -1 24 30 7 -1 4 9 26 6 16 -1 25 25 -1 -1 17 18 13 -1 -1 4 14 24 -1 4 14 17 32 4 7 13 13 22 4 12 19 4 24 6 9 8 4 4 -1 -1 9 
+>1_52_339_F3
+27 -1 33 24 28 32 29 17 25 27 26 30 30 31 -1 28 33 19 19 13 4 20 21 13 5 4 12 -1 4 23 13 8 4 10 4 6 5 7 4 8 4 8 12 5 12 10 8 7 -1 4
+"""
+    def tearDown(self):
+        shutil.rmtree(self.wd)
+    def test_getreads_fastq(self):
+        """getreads: read records from Fastq file
+        """
+        # Make an example file
+        example_fastq = os.path.join(self.wd,"example.fastq")
+        with open(example_fastq,'w') as fp:
+            fp.write(self.example_fastq_data)
+        # Read lines
+        fastq_reads = getreads(example_fastq)
+        reference_reads = [self.example_fastq_data.split('\n')[i:i+4]
+                           for i
+                           in xrange(0,
+                                     len(self.example_fastq_data.split('\n')),
+                                     4)]
+        for r1,r2 in zip(reference_reads,fastq_reads):
+            self.assertEqual(r1,r2)
+    def test_getreads_gzipped_fastq(self):
+        """getreads: read records from gzipped Fastq file
+        """
+        # Make an example file
+        example_fastq = os.path.join(self.wd,"example.fastq.gz")
+        with gzip.open(example_fastq,'w') as fp:
+            fp.write(self.example_fastq_data)
+        # Read lines
+        fastq_reads = getreads(example_fastq)
+        reference_reads = [self.example_fastq_data.split('\n')[i:i+4]
+                           for i
+                           in xrange(0,
+                                     len(self.example_fastq_data.split('\n')),
+                                     4)]
+        for r1,r2 in zip(reference_reads,fastq_reads):
+            self.assertEqual(r1,r2)
+    def test_getreads_csfasta(self):
+        """getreads: read records from csfasta file
+        """
+        # Make an example file
+        example_csfasta = os.path.join(self.wd,"example.csfasta")
+        with open(example_csfasta,'w') as fp:
+            fp.write(self.example_csfasta_data)
+        # Read lines
+        csfasta_reads = getreads(example_csfasta)
+        reference_reads = [self.example_csfasta_data.split('\n')[i:i+2]
+                           for i
+                           in xrange(2,
+                                     len(self.example_fastq_data.split('\n')),
+                                     2)]
+        for r1,r2 in zip(reference_reads,csfasta_reads):
+            self.assertEqual(r1,r2)
+    def test_getreads_qual(self):
+        """getreads: read records from qual file
+        """
+        # Make an example file
+        example_qual = os.path.join(self.wd,"example.qual")
+        with open(example_qual,'w') as fp:
+            fp.write(self.example_qual_data)
+        # Read lines
+        qual_reads = getreads(example_qual)
+        reference_reads = [self.example_qual_data.split('\n')[i:i+2]
+                           for i
+                           in xrange(2,
+                                     len(self.example_qual_data.split('\n')),
+                                     2)]
+        for r1,r2 in zip(reference_reads,qual_reads):
+            self.assertEqual(r1,r2)
+
+class TestGetreadsSubsetFunction(unittest.TestCase):
+    """Tests for the 'getreads_subset' function
+    """
+    def setUp(self):
+        self.wd = tempfile.mkdtemp()
+        self.example_fastq_data = """@K00311:43:HL3LWBBXX:8:1101:21440:1121 1:N:0:CNATGT
+GCCNGACAGCAGAAAT
++
+AAF#FJJJJJJJJJJJ
+@K00311:43:HL3LWBBXX:8:1101:21460:1121 1:N:0:CNATGT
+GGGNGTCATTGATCAT
++
+AAF#FJJJJJJJJJJJ
+@K00311:43:HL3LWBBXX:8:1101:21805:1121 1:N:0:CNATGT
+CCCNACCCTTGCCTAC
++
+AAF#FJJJJJJJJJJJ
+"""
+    def tearDown(self):
+        shutil.rmtree(self.wd)
+    def test_getreads_subset_fastq(self):
+        """getreads: get subset of reads from Fastq file
+        """
+        # Make an example file
+        example_fastq = os.path.join(self.wd,"example.fastq")
+        with open(example_fastq,'w') as fp:
+            fp.write(self.example_fastq_data)
+        # Get subset
+        fastq_reads = getreads_subset(example_fastq,
+                                      indices=(0,2))
+        reference_reads = [self.example_fastq_data.split('\n')[i:i+4]
+                           for i in (0,8)]
+        for r1,r2 in zip(reference_reads,fastq_reads):
+            self.assertEqual(r1,r2)
+
+class TestGetreadsRegexpFunction(unittest.TestCase):
+    """Tests for the 'getreads_regex' function
+    """
+    def setUp(self):
+        self.wd = tempfile.mkdtemp()
+        self.example_fastq_data = """@K00311:43:HL3LWBBXX:8:1101:21440:1121 1:N:0:CNATGT
+GCCNGACAGCAGAAAT
++
+AAF#FJJJJJJJJJJJ
+@K00311:43:HL3LWBBXX:8:1101:21460:1121 1:N:0:CNATGT
+GGGNGTCATTGATCAT
++
+AAF#FJJJJJJJJJJJ
+@K00311:43:HL3LWBBXX:8:1101:21805:1121 1:N:0:CNATGT
+CCCNACCCTTGCCTAC
++
+AAF#FJJJJJJJJJJJ
+"""
+    def tearDown(self):
+        shutil.rmtree(self.wd)
+    def test_getreads_regexp_fastq(self):
+        """getreads: get reads from Fastq file matching pattern
+        """
+        # Make an example file
+        example_fastq = os.path.join(self.wd,"example.fastq")
+        with open(example_fastq,'w') as fp:
+            fp.write(self.example_fastq_data)
+        # Get subset
+        fastq_reads = getreads_regex(example_fastq,
+                                      ":1101:21440:1121")
+        reference_reads = [self.example_fastq_data.split('\n')[i:i+4]
+                           for i in (0,)]
+        for r1,r2 in zip(reference_reads,fastq_reads):
+            self.assertEqual(r1,r2)
+
+class TestReadSizeFunction(unittest.TestCase):
+    """Tests for the 'read_size' function
+    """
+    def test_read_size_fastq(self):
+        """
+        read_size: check '.fastq' extension
+        """
+        self.assertEqual(read_size("test.fastq"),4)
+    def test_read_size_fastq_gz(self):
+        """
+        read_size: check '.fastq.gz' extension
+        """
+        self.assertEqual(read_size("test.fastq.gz"),4)
+    def test_read_size_fq(self):
+        """
+        read_size: check '.fq' extension
+        """
+        self.assertEqual(read_size("test.fq"),4)
+    def test_read_size_fq_gz(self):
+        """
+        read_size: check '.fq.gz' extension
+        """
+        self.assertEqual(read_size("test.fq.gz"),4)
+    def test_read_size_csfasta(self):
+        """
+        read_size: check '.csfasta' extension
+        """
+        self.assertEqual(read_size("test.csfasta"),2)
+    def test_read_size_csfasta_gz(self):
+        """
+        read_size: check '.csfasta.gz' extension
+        """
+        self.assertEqual(read_size("test.csfasta.gz"),2)
+    def test_read_size_qual(self):
+        """
+        read_size: check '.qual' extension
+        """
+        self.assertEqual(read_size("test.qual"),2)
+    def test_read_size_qual_gz(self):
+        """
+        read_size: check '.qual.gz' extension
+        """
+        self.assertEqual(read_size("test.qual.gz"),2)
+

--- a/bcftbx/test/test_utils.py
+++ b/bcftbx/test/test_utils.py
@@ -5,6 +5,7 @@ import unittest
 import os
 import tempfile
 import shutil
+import gzip
 import bcftbx.test.mock_data as mock_data
 from bcftbx.utils import *
 
@@ -106,6 +107,49 @@ class TestOrderedDictionary(unittest.TestCase):
                 pass
         except KeyError:
             self.fail("Iteration over OrderedDictionary failed")
+
+class TestGetlinesFunction(unittest.TestCase):
+    """Unit tests for the getlines function
+    """
+    def setUp(self):
+        self.wd = tempfile.mkdtemp()
+        self.example_text = """@K00311:43:HL3LWBBXX:8:1101:21440:1121 1:N:0:CNATGT
+GCCNGACAGCAGAAAT
++
+AAF#FJJJJJJJJJJJ
+@K00311:43:HL3LWBBXX:8:1101:21460:1121 1:N:0:CNATGT
+GGGNGTCATTGATCAT
++
+AAF#FJJJJJJJJJJJ
+@K00311:43:HL3LWBBXX:8:1101:21805:1121 1:N:0:CNATGT
+CCCNACCCTTGCCTAC
++
+AAF#FJJJJJJJJJJJ
+"""
+    def tearDown(self):
+        shutil.rmtree(self.wd)
+    def test_getlines(self):
+        """getlines: read lines from a file
+        """
+        # Make an example file
+        example_file = os.path.join(self.wd,"example.txt")
+        with open(example_file,'w') as fp:
+            fp.write(self.example_text)
+        # Read lines
+        lines = getlines(example_file)
+        for l1,l2 in zip(self.example_text.split('\n'),lines):
+            self.assertEqual(l1,l2)
+    def test_getlines_from_gzipped_file(self):
+        """getlines: read lines from a gzipped file
+        """
+        # Make an example gzipped file
+        example_file = os.path.join(self.wd,"example.txt.gz")
+        with gzip.open(example_file,'w') as fp:
+            fp.write(self.example_text)
+        # Read lines
+        lines = getlines(example_file)
+        for l1,l2 in zip(self.example_text.split('\n'),lines):
+            self.assertEqual(l1,l2)
 
 class TestPathInfo(unittest.TestCase):
     """Unit tests for the PathInfo utility class

--- a/bcftbx/utils.py
+++ b/bcftbx/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
-#     ngsutils.py: utility classes & functions specific to NGS applications
-#     Copyright (C) University of Manchester 2017 Peter Briggs
+#     utils.py: utility classes and functions shared between BCF codes
+#     Copyright (C) University of Manchester 2013-17 Peter Briggs
 #
 ########################################################################
 #

--- a/bcftbx/utils.py
+++ b/bcftbx/utils.py
@@ -1,5 +1,7 @@
-#     utils.py: utility classes and functions shared between BCF codes
-#     Copyright (C) University of Manchester 2013-14 Peter Briggs
+#!/usr/bin/env python
+#
+#     ngsutils.py: utility classes & functions specific to NGS applications
+#     Copyright (C) University of Manchester 2017 Peter Briggs
 #
 ########################################################################
 #
@@ -7,7 +9,7 @@
 #
 #########################################################################
 
-__version__ = "1.5.2"
+__version__ = "1.6.0"
 
 """utils
 

--- a/bcftbx/utils.py
+++ b/bcftbx/utils.py
@@ -18,6 +18,10 @@ General utility classes:
   AttributeDictionary
   OrderedDictionary
 
+File reading utilities:
+
+  getlines
+
 File system wrappers and utilities:
 
   PathInfo
@@ -85,6 +89,13 @@ import grp
 import datetime
 import re
 import socket
+
+#######################################################################
+# Module constants
+#######################################################################
+
+# Default size of data to read from file
+CHUNKSIZE = 102400
 
 #######################################################################
 # General utility classes
@@ -196,6 +207,70 @@ class OrderedDictionary:
             self.__dict[key] = value
         else:
             raise KeyError, "Key '%s' already exists" % key
+
+#######################################################################
+# File reading utilities
+#######################################################################
+
+def getlines(filen):
+    """
+    Fetch lines from a file and return them one by one
+
+    This generator function tries to implement an efficient
+    method of reading lines sequentially from a file, by
+    minimising the number of reads from the file and
+    performing the line splitting in memory. It attempts
+    to replicate the idiom:
+
+    >>> for line in open(filen):
+    >>> ...
+
+    using:
+
+    >>> for line in getlines(filen):
+    >>> ...
+
+    The file can be gzipped; this function should handle
+    this invisibly provided that the file extension is
+    '.gz'.
+
+    Arguments:
+      filen (str): path of the file to read lines from
+
+    Yields:
+      String: next line of text from the file, with any
+        newline character removed.
+    """
+    if filen.split('.')[-1] == 'gz':
+        fp = gzip.open(filen,'rb')
+    else:
+        fp = open(filen,'rb')
+    # Read in data in chunks
+    buf = ''
+    lines = []
+    while True:
+        # Grab a chunk of data
+        data = fp.read(CHUNKSIZE)
+        # Check for EOF
+        if not data:
+            break
+        # Add to buffer and split into lines
+        buf = buf + data
+        if buf[0] == '\n':
+            buf = buf[1:]
+        if buf[-1] != '\n':
+            i = buf.rfind('\n')
+            if i == -1:
+                continue
+            else:
+                lines = buf[:i].split('\n')
+                buf = buf[i+1:]
+        else:
+            lines = buf[:-1].split('\n')
+            buf = ''
+        # Return the lines one at a time
+        for line in lines:
+            yield line
 
 #######################################################################
 # File system wrappers and utilities

--- a/docs/source/bcftbx.rst
+++ b/docs/source/bcftbx.rst
@@ -18,3 +18,4 @@
    bcftbx/qc
    bcftbx/htmlpagewriter
    bcftbx/utils
+   bcftbx/ngsutils

--- a/docs/source/bcftbx/ngsutils.rst
+++ b/docs/source/bcftbx/ngsutils.rst
@@ -3,7 +3,9 @@
 
 .. automodule:: bcftbx.ngsutils
 
+Extracting reads from Fastq, cfasta and qual files
+**************************************************
+
 .. autofunction:: getreads
 .. autofunction:: getreads_subset
 .. autofunction:: getreads_regex
-.. autofunction:: read_size

--- a/docs/source/bcftbx/ngsutils.rst
+++ b/docs/source/bcftbx/ngsutils.rst
@@ -1,0 +1,9 @@
+``bcftbx.ngsutils``
+===================
+
+.. automodule:: bcftbx.ngsutils
+
+.. autofunction:: getreads
+.. autofunction:: getreads_subset
+.. autofunction:: getreads_regex
+.. autofunction:: read_size

--- a/docs/source/bcftbx/utils.rst
+++ b/docs/source/bcftbx/utils.rst
@@ -9,6 +9,11 @@ General utility classes
 .. autoclass:: AttributeDictionary
 .. autoclass:: OrderedDictionary
 
+File handling utilities
+***********************
+
+.. autofunction:: getlines
+
 File system wrappers and utilities
 **********************************
 


### PR DESCRIPTION
PR to move the generic file reading functions from the `extract_reads.py` utility into the `bcftbx` Python library, to enable reuse elsewhere:

* `getlines`: generic buffered line-by-line file reader
* `get_read_size`: return number of lines per record depending in sequence file based on file extension
* `getreads`, `getreads_subset`, `getreads_regexp`: extract reads from a sequence file