### PR TITLE
Implement utility to determine strandedness for Fastq R1/R2 pairs

### DIFF
--- a/QC-pipeline/README.markdown
+++ b/QC-pipeline/README.markdown
@@ -47,6 +47,9 @@ There are other scripts which perform QC substeps:
 
 These also use `functions.sh` and `ngs_utils.sh` from the `share` directory.
 
+The `strand_tsar.py` utility can be used to determine the strandedness of
+paired-end data.
+
 Finally there is a reporting utility which generates HTML reports from QC runs:
 
 *   `qcreporter.py`: creates HTML report plus `zip` archive for specified

--- a/QC-pipeline/strand_tsar.py
+++ b/QC-pipeline/strand_tsar.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+#
+#     strand_tsar.py: determine strandedness of fastq pair using STAR
+#     Copyright (C) University of Manchester 2017 Peter Briggs
+#
+#######################################################################
+# Imports
+#######################################################################
+
+import sys
+import os
+import argparse
+import tempfile
+import random
+import subprocess
+import shutil
+import logging
+from bcftbx.utils import find_program
+from bcftbx.ngsutils import getreads
+from bcftbx.ngsutils import getreads_subset
+
+#######################################################################
+# Main script
+#######################################################################
+
+if __name__ == "__main__":
+    # Process command line
+    p = argparse.ArgumentParser(
+        description="Generate strandedness statistics "
+        "for FASTQ pair")
+    p.add_argument("r1",metavar="R1",
+                   default=None,
+                   help="R1 Fastq file")
+    p.add_argument("r2",metavar="R2",
+                   default=None,
+                   help="R2 Fastq file")
+    p.add_argument("star_genomedir",metavar="STAR_GENOMEDIR",
+                   default=None,
+                   help="STAR genomeDir")
+    p.add_argument("--subset",
+                   type=int,
+                   default=10000,
+                   help="use a random subset of read pairs "
+                   "from the input Fastqs (default: 10000)")
+    p.add_argument("-n",
+                   type=int,
+                   default=1,
+                   help="number of threads to run STAR with "
+                   "(--runThreadN; default: 1)")
+    args = p.parse_args()
+    # Check that STAR is on the path
+    star_exe = find_program("STAR")
+    if star_exe is None:
+        logging.critical("STAR not found")
+        sys.exit(1)
+    # Prefix for output
+    prefix = "strand_tsar_"
+    # Create a temporary working directory
+    working_dir = tempfile.mkdtemp(suffix=".strand_tsar",
+                                   dir=os.getcwd())
+    # Make subset of input read pairs
+    nreads = sum(1 for i in getreads(os.path.abspath(args.r1)))
+    print "%d reads" % nreads
+    if args.subset > nreads:
+        print "Actual number of read pairs smaller than requested subset"
+        subset = nreads
+    else:
+        subset = args.subset
+        print "Using random subset of %d read pairs" % subset
+    subset_indices = random.sample(xrange(nreads),subset)
+    fastqs = []
+    for fq in (args.r1,args.r2):
+        fq_subset = os.path.join(working_dir,
+                                 os.path.basename(fq))
+        if fq_subset.endswith(".gz"):
+            fq_subset = '.'.join(fq_subset.split('.')[:-1])
+        fq_subset = "%s.subset.fq" % '.'.join(fq_subset.split('.')[:-1])
+        with open(fq_subset,'w') as fp:
+            for read in getreads_subset(os.path.abspath(fq),
+                                        subset_indices):
+                fp.write('\n'.join(read) + '\n')
+        fastqs.append(fq_subset)
+    # Build a command line to run STAR
+    star_cmd = [star_exe,
+                '--runMode','alignReads',
+                '--genomeLoad','NoSharedMemory',
+                '--genomeDir',os.path.abspath(args.star_genomedir),
+                '--readFilesIn',
+                fastqs[0],
+                fastqs[1],
+                '--quantMode','GeneCounts',
+                '--outSAMtype','BAM','Unsorted',
+                '--outSAMstrandField','intronMotif',
+                '--outFileNamePrefix',prefix,
+                '--runThreadN',str(args.n)]
+    print "Running %s" % ' '.join(star_cmd)
+    subprocess.check_output(star_cmd,cwd=working_dir)
+    # Process the STAR output
+    out_file = os.path.join(working_dir,
+                            "%sReadsPerGene.out.tab" % prefix)
+    if not os.path.exists(out_file):
+        raise Exception("Failed to find .out file: %s" % out_file)
+    sum_col2 = 0
+    sum_col3 = 0
+    sum_col4 = 0
+    with open(out_file) as out:
+        for i,line in enumerate(out):
+            if i < 4:
+                # Skip first four lines
+                continue
+            # Process remaining delimited columns
+            cols = line.rstrip('\n').split('\t')
+            sum_col2 += int(cols[1])
+            sum_col3 += int(cols[2])
+            sum_col4 += int(cols[3])
+    print "Sums:"
+    print "- col2: %d" % sum_col2
+    print "- col3: %d" % sum_col3
+    print "- col4: %d" % sum_col4
+    forward_1st = float(sum_col3)/float(sum_col4)*100.0
+    reverse_2nd = float(sum_col2)/float(sum_col4)*100.0
+    print "Strand percentages:"
+    print "- 1st forward: %.2f%%" % forward_1st
+    print "- 2nd reverse: %.2f%%" % reverse_2nd
+    # Clean up the working dir
+    shutil.rmtree(working_dir)

--- a/docs/source/reference/qc_pipeline.rst
+++ b/docs/source/reference/qc_pipeline.rst
@@ -11,6 +11,7 @@ sequencing data prior to library-specific analyses.
 * :ref:`boxplotps2png`: make PNGs of PS plots from :ref:`qc_boxplotter`
 * :ref:`solid_preprocess_filter`
 * :ref:`solid_preprocess_truncation_filter`
+* :ref:`strand_tsar`
 
 .. _run_qc_pipeline:
 
@@ -385,3 +386,18 @@ The script also writes statistics on the numbers of input/output reads to the
 
 Other options supplied to the script are directly passed to the underlying
 ``SOLiD_preprocess_filter_v2.pl`` program
+
+.. _strand_tsar:
+
+strand_tsar.py
+**************
+
+Utility to determine the strandedness (forward, reverse, or both) from
+an R1/R2 pair of Fastq files.
+
+Requires that the ``STAR`` mapper is also installed and available on the
+user's ``PATH``.
+
+Example usage::
+
+    strand_tsar.py R1.fastq.gz R2.fastq.gz STARindex/mm10


### PR DESCRIPTION
WIP PR which implements a utility (`strand_tsar.py`) which tries to determine the strandedness of a Fastq R1/R2 pair, by running the `STAR` mapper and totalling the mapped forward and reverse reads.

Utility requested by @leozeef.