### PR TITLE
bcftbx/utils: enable 'mkdir' function to make missing intermediate directories

### DIFF
--- a/bcftbx/test/test_utils.py
+++ b/bcftbx/test/test_utils.py
@@ -618,6 +618,49 @@ class TestFileSystemFunctions(unittest.TestCase):
         self.assertEqual('name',strip_ext('name.fastq'))
         self.assertEqual('name.fastq',strip_ext('name.fastq.gz'))
 
+class TestMkdirFunction(unittest.TestCase):
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+
+    def test_mkdir(self):
+        """mkdir: make a single subdirectory
+        """
+        new_dir = os.path.join(self.test_dir,"new_dir")
+        self.assertFalse(os.path.exists(new_dir))
+        mkdir(new_dir)
+        self.assertTrue(os.path.exists(new_dir))
+
+    def test_mkdir_chmod(self):
+        """mkdir: make a subdirectory and set permissions
+        """
+        new_dir = os.path.join(self.test_dir,"new_dir")
+        self.assertFalse(os.path.exists(new_dir))
+        mkdir(new_dir,mode=0644)
+        self.assertTrue(os.path.exists(new_dir))
+        self.assertEqual(stat.S_IMODE(os.lstat(new_dir).st_mode),0644)
+
+    def test_mkdir_dir_already_exists(self):
+        """mkdir: try to make a subdirectory that already exists
+        """
+        new_dir = os.path.join(self.test_dir,"new_dir")
+        os.mkdir(new_dir)
+        self.assertTrue(os.path.exists(new_dir))
+        mkdir(new_dir)
+        self.assertTrue(os.path.exists(new_dir))
+
+    def test_mkdir_dir_recursive(self):
+        """mkdir: make a subdirectory recursive
+        """
+        new_dir = os.path.join(self.test_dir,"new_dir","subdir","test")
+        self.assertFalse(os.path.exists(new_dir))
+        mkdir(new_dir,recursive=True)
+        self.assertTrue(os.path.exists(new_dir))
+
 class TestChmodFunction(unittest.TestCase):
 
     def setUp(self):

--- a/bcftbx/test/test_utils.py
+++ b/bcftbx/test/test_utils.py
@@ -654,11 +654,28 @@ class TestMkdirFunction(unittest.TestCase):
         self.assertTrue(os.path.exists(new_dir))
 
     def test_mkdir_dir_recursive(self):
-        """mkdir: make a subdirectory recursive
+        """mkdir: make a subdirectory recursively
         """
         new_dir = os.path.join(self.test_dir,"new_dir","subdir","test")
         self.assertFalse(os.path.exists(new_dir))
         mkdir(new_dir,recursive=True)
+        self.assertTrue(os.path.exists(new_dir))
+
+class TestMkdirsFunction(unittest.TestCase):
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+
+    def test_mkdir_dir_recursive(self):
+        """mkdirs: make a subdirectory recursively
+        """
+        new_dir = os.path.join(self.test_dir,"new_dir","subdir","test")
+        self.assertFalse(os.path.exists(new_dir))
+        mkdirs(new_dir)
         self.assertTrue(os.path.exists(new_dir))
 
 class TestChmodFunction(unittest.TestCase):

--- a/bcftbx/utils.py
+++ b/bcftbx/utils.py
@@ -593,19 +593,26 @@ class PathInfo:
         """
         return str(self.__path)
 
-def mkdir(dirn,mode=None):
+def mkdir(dirn,mode=None,recursive=False):
     """Make a directory
 
     Arguments:
       dirn: the path of the directory to be created
       mode: (optional) a mode specifier to be applied to the
         new directory once it has been created e.g. 0775 or 0664
-
+      recursive: (optional) if True then also create any
+        intermediate parent directories if they don't already
+        exist
     """
-    logging.debug("Making %s" % dirn)
-    if not os.path.isdir(dirn):
-        os.mkdir(dirn)
-        if mode is not None: chmod(dirn,mode)
+    if os.path.exists(dirn):
+	return
+    if recursive:
+        parent = os.path.dirname(dirn)
+        if not os.path.exists(parent):
+            mkdir(parent,recursive=True)
+    logging.debug("Making dir:%s" % dirn)
+    os.mkdir(dirn)
+    if mode is not None: chmod(dirn,mode)
 
 def mklink(target,link_name,relative=False):
     """Make a symbolic link

--- a/bcftbx/utils.py
+++ b/bcftbx/utils.py
@@ -28,6 +28,7 @@ File system wrappers and utilities:
 
   PathInfo
   mkdir
+  mkdirs
   mklink
   chmod
   touch
@@ -613,6 +614,16 @@ def mkdir(dirn,mode=None,recursive=False):
     logging.debug("Making dir:%s" % dirn)
     os.mkdir(dirn)
     if mode is not None: chmod(dirn,mode)
+
+def mkdirs(dirn,mode=None):
+    """Make a directory recursively
+
+    Arguments:
+      dirn: the path of the directory to be created
+      mode: (optional) a mode specifier to be applied to the
+        new directory once it has been created e.g. 0775 or 0664
+    """
+    return mkdir(dirn,mode=mode,recursive=True)
 
 def mklink(target,link_name,relative=False):
     """Make a symbolic link


### PR DESCRIPTION
PR to enable the `mkdir` function to create any missing intermediate directories, if new `recursive` option is set to `True`. Default remains to operate non-recursively.