### PR TITLE
Fix SimpleJobRunner.list() to handle missing job ids

### DIFF
--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -320,7 +320,11 @@ class SimpleJobRunner(BaseJobRunner):
                 logging.debug("Job id %s: finished (%s)" % (job_id,
                                                             status))
                 self.__exit_status[job_id] = status
-                del(self.__job_popen[job_id])
+                try:
+                    del(self.__job_popen[job_id])
+                except KeyError:
+                    logging.warning("Job id %s: already deleted"
+                                    % job_id)
         return job_ids
 
     def exit_status(self,job_id):


### PR DESCRIPTION
Sometimes errors are seen in the unit testing of the https://github.com/fls-bioinformatics-core/auto_process_ngs repo which come from the `list` method of the `bcftbx.JobRunner.SimpleJobRunner` class: a `KeyError` exception is raised from the line:

    del(self.__job_popen[job_id])

presumably because the job has finished and the dictionary entry has been removed by some background process (as this is an intermittent error it's difficult to check).

This PR adds a `try/except` block to handle this specific error and emit a warning.