### PR TITLE
Docstring and code tidying for cmdparse module

### DIFF
--- a/bcftbx/cmdparse.py
+++ b/bcftbx/cmdparse.py
@@ -102,7 +102,6 @@ class CommandParser(object):
             subparser = optparse.OptionParser
         self._subparser = subparser
 
-
     def add_command(self,cmd,help=None,**args):
         """Add a major command to the CommandParser
 

--- a/bcftbx/cmdparse.py
+++ b/bcftbx/cmdparse.py
@@ -65,7 +65,6 @@ class CommandParser(object):
 
     >>> p = CommandParser(subparser=argparser.ArgumentParser)
 
-
     Add a 'setup' command:
 
     >>> p.add_command('setup',usage='%prog setup OPTIONS ARGS')
@@ -104,7 +103,7 @@ class CommandParser(object):
         self._subparser = subparser
 
 
-    def add_command(self, cmd, help=None, **args):
+    def add_command(self,cmd,help=None,**args):
         """Add a major command to the CommandParser
 
         Adds a command and creates an initial ArgumentParser
@@ -143,7 +142,7 @@ class CommandParser(object):
         """
         return self._commands[cmd]
 
-    def parse_args(self, argv=None):
+    def parse_args(self,argv=None):
         """Process a command line
 
         Arguments:
@@ -175,37 +174,37 @@ class CommandParser(object):
             # No parser
             self.error("Usage: %s COMMAND [options] [args...]\n\n"
                        "%s: error: no such command: %s" %
-                       (self._name, self._name, cmd))
+                       (self._name,self._name,cmd))
 
         # Parse the remaining arguments and return
-        if isinstance(p, argparse.ArgumentParser):
+        if isinstance(p,argparse.ArgumentParser):
             options = p.parse_args(argv[1:])
-            return (cmd, options)
+            return (cmd,options)
         # else:
-        options, arguments = p.parse_args(argv[1:])
-        return (cmd, options, arguments)
+        options,arguments = p.parse_args(argv[1:])
+        return (cmd,options,arguments)
 
-    def error(self, message):
+    def error(self,message):
         """Exit with error message
 
         """
         sys.stderr.write("%s\n" % message)
         sys.exit(1)
 
-    def handle_generic_commands(self, cmd):
+    def handle_generic_commands(self,cmd):
         """Process 'generic' commands e.g. 'help'
 
         """
-        if cmd in ('-h', '--help', 'help'):
+        if cmd in ('-h','--help','help'):
             print "Usage: %s COMMAND [options] [args...]" % self._name
             if self._description is not None:
                 print "\n%s" % self._description
             print "%s" % self.print_available_commands()
             sys.exit(0)
-        if cmd in ('--version', ):
+        if cmd in ('--version',):
             if self._version is not None:
                 version_str = self._version
-                print "%s" % version_str.replace('%prog', self._name)
+                print "%s" % version_str.replace('%prog',self._name)
             sys.exit(0)
 
     def list_commands(self):
@@ -231,18 +230,18 @@ class CommandParser(object):
         # Add custom commands
         lines.append("\nAvailable commands:")
         for cmd in self.list_commands():
-            lines.append(self.print_command(cmd, self._help[cmd]))
+            lines.append(self.print_command(cmd,self._help[cmd]))
         lines.append("")
         return '\n'.join(lines)
 
-    def print_command(self, cmd, message=None):
+    def print_command(self,cmd,message=None):
         """Print a line for a single command
 
         Returns a 'pretty-printed' line for the specified command
         and text, with standard whitespace formatting.
 
         """
-        text = ['  ', cmd]
+        text = ['  ',cmd]
         width = 22
         if len(cmd) < width:
             text.append(' '*(width-len(cmd)))
@@ -256,7 +255,7 @@ class CommandParser(object):
 # Functions
 #######################################################################
 
-def add_nprocessors_option(parser, default_nprocessors, default_display=None):
+def add_nprocessors_option(parser,default_nprocessors,default_display=None):
     """Add a '--nprocessors' option to a parser
 
     Given an OptionParser 'parser', add a '--nprocessors' option.
@@ -272,12 +271,12 @@ def add_nprocessors_option(parser, default_nprocessors, default_display=None):
     """
     if default_display is None:
         default_display = default_nprocessors
-    if isinstance(parser, argparse.ArgumentParser):
+    if isinstance(parser,argparse.ArgumentParser):
         add_cmd = parser.add_argument
     else:
         add_cmd = parser.add_option
-    add_cmd('--nprocessors', action='store',
-            dest='nprocessors', default=default_nprocessors,
+    add_cmd('--nprocessors',action='store',
+            dest='nprocessors',default=default_nprocessors,
             help="explicitly specify number of processors/cores to use "
             "(default %s)" %default_display)
     return parser
@@ -295,12 +294,12 @@ def add_runner_option(parser):
     Returns the input ArgumentParser object.
 
     """
-    if isinstance(parser, argparse.ArgumentParser):
+    if isinstance(parser,argparse.ArgumentParser):
         add_cmd = parser.add_argument
     else:
         add_cmd = parser.add_option
-    add_cmd('--runner', action='store',
-            dest='runner', default=None,
+    add_cmd('--runner',action='store',
+            dest='runner',default=None,
             help="explicitly specify runner definition (e.g. "
             "'GEJobRunner(-j y)')")
     return parser
@@ -316,11 +315,11 @@ def add_no_save_option(parser):
     Returns the input ArgumentParser object.
 
     """
-    if isinstance(parser, argparse.ArgumentParser):
+    if isinstance(parser,argparse.ArgumentParser):
         add_cmd = parser.add_argument
     else:
         add_cmd = parser.add_option
-    add_cmd('--no-save', action='store_true', dest='no_save', default=False,
+    add_cmd('--no-save',action='store_true',dest='no_save',default=False,
             help="Don't save parameter changes to the auto_process.info file")
     return parser
 
@@ -335,11 +334,11 @@ def add_dry_run_option(parser):
     Returns the input OptionParser object.
 
     """
-    if isinstance(parser, argparse.ArgumentParser):
+    if isinstance(parser,argparse.ArgumentParser):
         add_cmd = parser.add_argument
     else:
         add_cmd = parser.add_option
-    add_cmd('--dry-run', action='store_true', dest='dry_run', default=False,
+    add_cmd('--dry-run',action='store_true',dest='dry_run',default=False,
             help="Dry run i.e. report what would be done but don't perform "
                  "any actions")
     return parser
@@ -355,10 +354,10 @@ def add_debug_option(parser):
     Returns the input ArgumentParser object.
 
     """
-    if isinstance(parser, argparse.ArgumentParser):
+    if isinstance(parser,argparse.ArgumentParser):
         add_cmd = parser.add_argument
     else:
         add_cmd = parser.add_option
-    add_cmd('--debug', action='store_true', dest='debug',
-            default=False, help="Turn on debugging output")
+    add_cmd('--debug',action='store_true',dest='debug',
+            default=False,help="Turn on debugging output")
     return parser

--- a/bcftbx/cmdparse.py
+++ b/bcftbx/cmdparse.py
@@ -5,19 +5,23 @@
 #########################################################################
 
 """
-Provides a CommandParser class built on top of the 'argparse.ArgumentParser'
-class, that can be used for handling command lines of the form::
+Provides a CommandParser class for handling command lines of the form::
 
     PROG COMMAND OPTION ARGS
 
 where different sets of options can be defined based on the initial
 command.
 
-The argparse.ArgumentParser may be specified to be used in place of optparse.OptionParser.
+The CommandParser can support arbitrary 'subparser backends' which are
+created to parse the ARGS list for each defined COMMAND. The default
+subparser is the 'optparse.OptionParser' class, but this can be swapped
+for arbitrary subparser (for example, the 'argparse.ArgumentParser'
+class) when the CommandParser is created.
 
 In addition to the core CommandParser class, there are a number of
-supporting functions that can be used with any argparse-based object to
-add 'standard' options:
+supporting functions that can be used with any optparse- or
+argparse-based parser instance, to add the following 'standard'
+options:
 
 * --nprocessors
 * --runner
@@ -56,12 +60,13 @@ class CommandParser(object):
 
     Usage:
 
-    Create a simple CommandParser
-    with OptionParser as the default backend using:
+    Create a simple CommandParser which uses optparse.OptionParser as
+    the default subparser backend using:
 
     >>> p = CommandParser()
     
-    or with ArgumentParser as the backend using:
+    Alternatively, specify argparse.ArgumentParser as the subparser
+    using:
 
     >>> p = CommandParser(subparser=argparser.ArgumentParser)
 
@@ -69,17 +74,22 @@ class CommandParser(object):
 
     >>> p.add_command('setup',usage='%prog setup OPTIONS ARGS')
 
-    Add options to the 'setup' command using normal OptionParser/ ArgumentParser methods,
-    e.g.
+    Add options to the 'setup' command using the appropriate methods
+    of the subparser (e.g. 'add_argument' for an
+    ArgumentParser instance).
 
-    >>> p.parser_for('info').add_option('-f',...)
+    For example:
 
-    To process a command line use the 'parse_args' method e.g.:
+    >>> p.parser_for('info').add_argument('-f',...)
+
+    To process a command line, use the 'parse_args' method, for
+    example for an OptionParser-based subparser:
 
     >>> cmd,options,args = p.parse_args()
 
-    The options and arguments can be accessed using the normal
-    methods from optparse.
+    Note that the exact form of the returned values depends on
+    on the subparser instance; it will be the same as that
+    returned by the 'parse_args' method of the subparser.
 
     """
     def __init__(self,description=None,version=None,subparser=None):
@@ -105,14 +115,14 @@ class CommandParser(object):
     def add_command(self,cmd,help=None,**args):
         """Add a major command to the CommandParser
 
-        Adds a command and creates an initial ArgumentParser
-        for it.
+        Adds a command, and creates and returns an initial
+        subparser instance for it.
 
         Arguments:
           cmd: the command to be added
           help: (optional) help text for the command
 
-        Other arguments are passed to the ArgumentParser object
+        Other arguments are passed to the subparser instance
         when it is created i.e. 'usage', 'version',
         'description'.
 
@@ -120,7 +130,7 @@ class CommandParser(object):
         supplied to the CommandParser object will be used.
 
         Returns:
-          ArgumentParser object for the command.
+          Subparser instance object for the command.
 
         """
         if cmd in self._commands:
@@ -144,18 +154,29 @@ class CommandParser(object):
     def parse_args(self,argv=None):
         """Process a command line
 
+        Parses a command line (either those supplied to the calling
+        subprogram e.g. via the Python interpreter, or as a list).
+
+        Once the command is identified from the first argument, the
+        remainder of the arguments are passed to the 'parse_args'
+        method of the appropriate subparser for that command.
+
+        This method returns a tuple, with the first value being the
+        command, and the rest of the values being those returned
+        from the 'parse_args' method of the subparser.
+
         Arguments:
           argv: (optional) a list consisting of a command line.
             If not supplied then defaults to sys.argv[1:].
 
         Returns:
-          A tuple of (cmd,options,arguments) if OptionParser (default)
-          backend is used where 'cmd' is the
-          command, and 'options' and 'arguments' are the options and
-          arguments as returned by OptionParser.parse_args.
-          A tuple of (cmd,options) if ArgumentParser is used as backend
-          where 'cmd' is the command and 'options' is as returned by
-          ArgumentParser.parse_args
+          A tuple of (cmd,...), where 'cmd' is the command, and '...'
+          represents the values returned from the 'parse_args' method
+          of the subparser. For example, using the default OptionParser
+          backend returns (cmd,options,arguments), where 'options' and
+          'arguments' are the options and arguments as returned by
+          OptionParser.parse_args; using ArgumentParser as a backend
+          returns (cmd,arguments).
 
         """
         # Collect arguments to process
@@ -174,7 +195,6 @@ class CommandParser(object):
             self.error("Usage: %s COMMAND [options] [args...]\n\n"
                        "%s: error: no such command: %s" %
                        (self._name,self._name,cmd))
-
         # Parse the remaining arguments and return
         if isinstance(p,argparse.ArgumentParser):
             options = p.parse_args(argv[1:])
@@ -257,7 +277,8 @@ class CommandParser(object):
 def add_nprocessors_option(parser,default_nprocessors,default_display=None):
     """Add a '--nprocessors' option to a parser
 
-    Given an OptionParser 'parser', add a '--nprocessors' option.
+    Given a parser instance 'parser' (either OptionParser or
+    ArgumentParser), add a '--nprocessors' option.
 
     The value of this option can be accessed via the 'nprocessors'
     attribute of the parser options.
@@ -265,7 +286,7 @@ def add_nprocessors_option(parser,default_nprocessors,default_display=None):
     If 'default_display' is not None then this value will be shown
     in the help text, rather than the value supplied for the default.
 
-    Returns the input ArgumentParser object.
+    Returns the input parser object.
 
     """
     if default_display is None:
@@ -279,14 +300,15 @@ def add_nprocessors_option(parser,default_nprocessors,default_display=None):
 def add_runner_option(parser):
     """Add a '--runner' option to a parser
 
-    Given an OptionParser 'parser', add a '--runner' option.
+    Given a parser instance 'parser' (either OptionParser or
+    ArgumentParser), add a '--runner' option.
 
     The value of this option can be accessed via the 'runner'
     attribute of the parser options (use the 'fetch_runner'
     function to return a JobRunner object from the supplied
     value).
 
-    Returns the input ArgumentParser object.
+    Returns the input parser object.
 
     """
     add_arg(parser,'--runner',action='store',
@@ -298,12 +320,13 @@ def add_runner_option(parser):
 def add_no_save_option(parser):
     """Add a '--no-save' option to a parser
 
-    Given an OptionParser 'parser', add a '--no-save' option.
+    Given a parser instance 'parser' (either OptionParser or
+    ArgumentParser), add a '--no-save' option.
 
     The value of this option can be accessed via the 'no_save'
     attribute of the parser options.
 
-    Returns the input ArgumentParser object.
+    Returns the input parser object.
 
     """
     add_arg(parser,'--no-save',action='store_true',
@@ -315,12 +338,13 @@ def add_no_save_option(parser):
 def add_dry_run_option(parser):
     """Add a '--dry-run' option to a parser
 
-    Given an OptionParser 'parser', add a '--dry-run' option.
+    Given a parser instance 'parser' (either OptionParser or
+    ArgumentParser), add a '--dry-run' option.
 
     The value of this option can be accessed via the 'dry_run'
     attribute of the parser options.
 
-    Returns the input OptionParser object.
+    Returns the input parser object.
 
     """
     add_arg(parser,'--dry-run',action='store_true',
@@ -332,12 +356,13 @@ def add_dry_run_option(parser):
 def add_debug_option(parser):
     """Add a '--debug' option to a parser
 
-    Given an OptionParser 'parser', add a '--debug' option.
+    Given a parser instance 'parser' (either OptionParser or
+    ArgumentParser), add a '--debug' option.
 
     The value of this option can be accessed via the 'debug'
     attribute of the parser options.
 
-    Returns the input ArgumentParser object.
+    Returns the input parser object.
 
     """
     add_arg(parser,'--debug',action='store_true',

--- a/bcftbx/cmdparse.py
+++ b/bcftbx/cmdparse.py
@@ -270,14 +270,10 @@ def add_nprocessors_option(parser,default_nprocessors,default_display=None):
     """
     if default_display is None:
         default_display = default_nprocessors
-    if isinstance(parser,argparse.ArgumentParser):
-        add_cmd = parser.add_argument
-    else:
-        add_cmd = parser.add_option
-    add_cmd('--nprocessors',action='store',
+    add_arg(parser,'--nprocessors',action='store',
             dest='nprocessors',default=default_nprocessors,
-            help="explicitly specify number of processors/cores to use "
-            "(default %s)" %default_display)
+            help="explicitly specify number of processors/cores "
+            "to use (default %s)" %default_display)
     return parser
 
 def add_runner_option(parser):
@@ -293,11 +289,7 @@ def add_runner_option(parser):
     Returns the input ArgumentParser object.
 
     """
-    if isinstance(parser,argparse.ArgumentParser):
-        add_cmd = parser.add_argument
-    else:
-        add_cmd = parser.add_option
-    add_cmd('--runner',action='store',
+    add_arg(parser,'--runner',action='store',
             dest='runner',default=None,
             help="explicitly specify runner definition (e.g. "
             "'GEJobRunner(-j y)')")
@@ -314,12 +306,10 @@ def add_no_save_option(parser):
     Returns the input ArgumentParser object.
 
     """
-    if isinstance(parser,argparse.ArgumentParser):
-        add_cmd = parser.add_argument
-    else:
-        add_cmd = parser.add_option
-    add_cmd('--no-save',action='store_true',dest='no_save',default=False,
-            help="Don't save parameter changes to the auto_process.info file")
+    add_arg(parser,'--no-save',action='store_true',
+            dest='no_save',default=False,
+            help="Don't save parameter changes to "
+            "the auto_process.info file")
     return parser
 
 def add_dry_run_option(parser):
@@ -333,13 +323,10 @@ def add_dry_run_option(parser):
     Returns the input OptionParser object.
 
     """
-    if isinstance(parser,argparse.ArgumentParser):
-        add_cmd = parser.add_argument
-    else:
-        add_cmd = parser.add_option
-    add_cmd('--dry-run',action='store_true',dest='dry_run',default=False,
-            help="Dry run i.e. report what would be done but don't perform "
-                 "any actions")
+    add_arg(parser,'--dry-run',action='store_true',
+            dest='dry_run',default=False,
+            help="Dry run i.e. report what would "
+            "be done but don't perform any actions")
     return parser
 
 def add_debug_option(parser):
@@ -353,10 +340,37 @@ def add_debug_option(parser):
     Returns the input ArgumentParser object.
 
     """
-    if isinstance(parser,argparse.ArgumentParser):
-        add_cmd = parser.add_argument
-    else:
-        add_cmd = parser.add_option
-    add_cmd('--debug',action='store_true',dest='debug',
-            default=False,help="Turn on debugging output")
+    add_arg(parser,'--debug',action='store_true',
+            dest='debug',default=False,
+            help="Turn on debugging output")
     return parser
+
+def add_arg(p,*args,**kwds):
+    """Add an argument or option to a parser
+
+    Given an arbitrary parser instance, adds a new
+    option or argument using the appropriate method
+    call and passing the supplied arguments and
+    keywords.
+
+    For example, if the parser is an instance of
+    argparse.ArgumentParser, then the 'add_argument'
+    method will be invoked to add a new
+
+    Arguments:
+      p (Object): parser instance; can be an instance
+        of one of: optparse.OptionParser or
+        argparse.ArgumentParser
+      args (List): list of argument values to pass
+        directly to the argument-addition method
+      kwds (mapping): keyword-value mapping to pass
+        directly to the argument-addition method
+
+    """
+    if isinstance(p,argparse.ArgumentParser):
+        add_arg = p.add_argument
+    elif isinstance(p,optparse.OptionParser):
+        add_arg = p.add_option
+    else:
+        raise Exception("Unrecognised subparser class")
+    return add_arg(*args,**kwds)


### PR DESCRIPTION
This PR makes some largely cosmetic updates to the `bcftbx/cmdparse.py` module, including:

* Updating docstrings to more accurately document usage following generalisation to allow `argparse` to be used for parser backend (PR #54)
* Re-establishing consistent coding style

(There is also some minor refactoring to abstract repeated code in the `add_*_command` functions.)

This PR contributes to addressing issue #46.