### PR TITLE
bcftbx/cmdparse: test 'add_arg' function and fix for optparseOptionGroup instances

### DIFF
--- a/bcftbx/cmdparse.py
+++ b/bcftbx/cmdparse.py
@@ -380,11 +380,13 @@ def add_arg(p,*args,**kwds):
 
     For example, if the parser is an instance of
     argparse.ArgumentParser, then the 'add_argument'
-    method will be invoked to add a new
+    method will be invoked to add a new argument to
+    the parser.
 
     Arguments:
       p (Object): parser instance; can be an instance
-        of one of: optparse.OptionParser or
+        of one of: optparse.OptionContainer (i.e.
+        OptionParser or OptionGroup), or
         argparse.ArgumentParser
       args (List): list of argument values to pass
         directly to the argument-addition method
@@ -394,7 +396,7 @@ def add_arg(p,*args,**kwds):
     """
     if isinstance(p,argparse.ArgumentParser):
         add_arg = p.add_argument
-    elif isinstance(p,optparse.OptionParser):
+    elif isinstance(p,optparse.OptionContainer):
         add_arg = p.add_option
     else:
         raise Exception("Unrecognised subparser class")

--- a/bcftbx/test/test_cmdparse.py
+++ b/bcftbx/test/test_cmdparse.py
@@ -4,6 +4,7 @@
 
 import unittest
 from optparse import OptionParser
+from optparse import OptionGroup
 from argparse import ArgumentParser
 from bcftbx.cmdparse import *
 
@@ -198,3 +199,25 @@ class TestAddOptionFunctions(unittest.TestCase):
         add_debug_option(p)
         args = p.parse_args(['--debug'])
         self.assertTrue(args.debug)
+    def test_add_arg_with_optionparser(self):
+        """add_arg works with OptionParser
+        """
+        p = OptionParser()
+        add_arg(p,'-n',action='store',dest='n')
+        options,args = p.parse_args(['-n','4'])
+        self.assertEqual(options.n,'4')
+    def test_add_arg_with_optiongroup(self):
+        """add_arg works with OptionGroup
+        """
+        p = OptionParser()
+        g = OptionGroup(p,'Suboptions')
+        add_arg(g,'-n',action='store',dest='n')
+        options,args = p.parse_args(['-n','4'])
+        self.assertEqual(options.n,'4')
+    def test_add_arg_with_argumentparser(self):
+        """add_arg works with ArgumentParser
+        """
+        p = ArgumentParser()
+        add_arg(p,'-n',action='store',dest='n')
+        args = p.parse_args(['-n','4'])
+        self.assertEqual(args.n,'4')


### PR DESCRIPTION
PR to fix bug with the "standard" option functions in `bcftbx.cmdparse` (e.g. `add_nprocessors`) when an instance of `optparse.OptionGroup` is supplied (see also comments in issue #46).

Updating `add_arg` to check for `OptionContainer` instances covers both `OptionParser` and `OptionGroup` (which are both subclassed off `OptionContainer`).