### PR TITLE
WIP utility to reorder chromosomes karyotypically in FASTA

### DIFF
--- a/NGS-general/reorder_fasta.py
+++ b/NGS-general/reorder_fasta.py
@@ -1,4 +1,28 @@
 #!/usr/bin/env python
+#
+#     reorder_fasta.py: reorder chromosomes in a FASTA file
+#     Copyright (C) University of Manchester 2018 Peter Briggs
+
+"""
+reorder_fasta.py
+
+Reorders the chromosome records from a FASTA file into 'kayrotypic'
+order, e.g.
+
+chr1
+chr2
+...
+chr10
+chr11
+
+Usage: reorder_fasta.py INFILE.fa
+
+The output FASTA file will be called 'INFILE.karyotypic.fa'.
+"""
+
+#######################################################################
+# Imports
+#######################################################################
 
 import sys
 import os
@@ -7,7 +31,38 @@ import itertools
 import tempfile
 import logging
 
+#######################################################################
+# Module metadata
+#######################################################################
+
+__description__ = \
+"""Reorder the chromosome records in a FASTA file into
+karyotypic order."""
+
+#######################################################################
+# Functions
+#######################################################################
+
 def split_chrom_name(s):
+    """
+    Split chromosome name for comparison and sorting
+
+    Splits a chromosome name into a list, to be
+    used in comparison and sorting operations.
+
+    For example:
+
+    >>> split_chrom_name("chr1")
+    ... [1]
+    >>> split_chrom_name("chr17_gl000203_random")
+    ... [17,"gl000203","random"]
+
+    Arguments:
+      s (str): chromosome name to split
+
+    Returns:
+      List: list representation of the name.
+    """
     s0 = s.split('_')
     if s0[0].startswith('chr'):
         s0[0] = s0[0][3:]
@@ -18,6 +73,20 @@ def split_chrom_name(s):
     return s0
 
 def cmp_chrom_names(x,y):
+    """
+    Compare two chromosome names karyotypically
+
+    Implements the 'cmp' function to compare two chromosomes
+    names karyotypically.
+
+    Arguments:
+      x (str): first chromosome name
+      y (str): second chromosome name
+
+    Returns:
+      Integer: negative if x < y, zero if x == y, positive if
+        x > y.
+    """
     for i,j in itertools.izip_longest(split_chrom_name(x),
                                       split_chrom_name(y)):
         c = cmp(i,j)
@@ -25,15 +94,56 @@ def cmp_chrom_names(x,y):
             return c
     return 0
 
-if __name__ == "__main__":
-    p = argparse.ArgumentParser()
-    p.add_argument("fasta",
+#######################################################################
+# Unit tests
+#######################################################################
+
+import unittest
+
+class TestSplitChromName(unittest.TestCase):
+    def test_split_chrom_name(self):
+        self.assertEqual(split_chrom_name("chr1"),[1])
+        self.assertEqual(split_chrom_name("chr10"),[10])
+        self.assertEqual(split_chrom_name("chrX"),["X"])
+        self.assertEqual(split_chrom_name("chr21_gl000210_random"),
+                                          [21,"gl000210","random"])
+
+class TestCmpChromNames(unittest.TestCase):
+    def test_cmp_chrom_names_equal(self):
+        self.assertTrue(cmp_chrom_names("chr1","chr1") == 0)
+        self.assertTrue(cmp_chrom_names("chr10","chr10") == 0)
+        self.assertTrue(cmp_chrom_names("chr17_gl000203_random",
+                                        "chr17_gl000203_random") == 0)
+    def test_cmp_chrom_names_lt(self):
+        self.assertTrue(cmp_chrom_names("chr1","chr10") < 0)
+        self.assertTrue(cmp_chrom_names("chr1",
+                                        "chr17_gl000203_random") < 0)
+        self.assertTrue(cmp_chrom_names("chr17",
+                                        "chr17_gl000203_random") < 0)
+    def test_cmp_chrom_names_gt(self):
+        self.assertTrue(cmp_chrom_names("chr10","chr1") > 0)
+        self.assertTrue(cmp_chrom_names("chr17_gl000203_random",
+                                        "chr1") > 0)
+        self.assertTrue(cmp_chrom_names("chr17_gl000203_random",
+                                        "chr17") > 0)
+
+#######################################################################
+# Main
+#######################################################################
+
+def main(args=None):
+    # Process command line
+    if args is None:
+        args = sys.argv[1:]
+    p = argparse.ArgumentParser(description=__description__)
+    p.add_argument("fasta",metavar="FASTA",
                    help="FASTA file to reorder")
     args = p.parse_args()
     fasta = os.path.abspath(args.fasta)
     if not os.path.exists(fasta):
         logging.critical("%s: file not found" % fasta)
         sys.exit(1)
+    # Extract each chromosome to its own temporary file
     print "Extracting chromosomes..."
     chroms = list()
     wd = tempfile.mkdtemp()
@@ -42,17 +152,26 @@ if __name__ == "__main__":
         chromfile = None
         for line in fp:
             if line.startswith(">"):
+                # New chromosome encountered
                 if chromfile is not None:
                     chromfile.close()
+                # Extract chromosome name
                 chrom = line.strip()[1:]
                 print "\t%s" % chrom
+                if chrom in chroms:
+                    logging.critical("%s: chromosome appears more "
+                                     "than once" % chrom)
+                    sys.exit(1)
                 chroms.append(chrom)
+                # Open a new file
                 chromfile = open(os.path.join(wd,"%s.fa" % chrom),'w')
+            # Write chromosome data to temporary file
             chromfile.write(line)
     if chromfile is not None:
         chromfile.close()
     print "Found %d chromosomes" % len(chroms)
     chroms = sorted(chroms,cmp=cmp_chrom_names)
+    # Assemble new fasta file in karyotypic order
     print "Reordering chromosomes..."
     fasta_reordered = "%s.%s%s" % (
         os.path.splitext(os.path.basename(fasta))[0],
@@ -66,3 +185,6 @@ if __name__ == "__main__":
                 fp.write(fpp.read())
     print "Wrote reordered FASTA file to %s" % fasta_reordered
     print "Finished"
+
+if __name__ == "__main__":
+    main()

--- a/NGS-general/reorder_fasta.py
+++ b/NGS-general/reorder_fasta.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+import sys
+import os
+import argparse
+import itertools
+import tempfile
+import logging
+
+def split_chrom_name(s):
+    s0 = s.split('_')
+    if s0[0].startswith('chr'):
+        s0[0] = s0[0][3:]
+        try:
+            s0[0] = int(s0[0])
+        except ValueError:
+            pass
+    return s0
+
+def cmp_chrom_names(x,y):
+    for i,j in itertools.izip_longest(split_chrom_name(x),
+                                      split_chrom_name(y)):
+        c = cmp(i,j)
+        if c != 0:
+            return c
+    return 0
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("fasta",
+                   help="FASTA file to reorder")
+    args = p.parse_args()
+    fasta = os.path.abspath(args.fasta)
+    if not os.path.exists(fasta):
+        logging.critical("%s: file not found" % fasta)
+        sys.exit(1)
+    print "Extracting chromosomes..."
+    chroms = list()
+    wd = tempfile.mkdtemp()
+    print "Using working dir %s" % wd
+    with open(fasta,'rU') as fp:
+        chromfile = None
+        for line in fp:
+            if line.startswith(">"):
+                if chromfile is not None:
+                    chromfile.close()
+                chrom = line.strip()[1:]
+                print "\t%s" % chrom
+                chroms.append(chrom)
+                chromfile = open(os.path.join(wd,"%s.fa" % chrom),'w')
+            chromfile.write(line)
+    if chromfile is not None:
+        chromfile.close()
+    print "Found %d chromosomes" % len(chroms)
+    chroms = sorted(chroms,cmp=cmp_chrom_names)
+    print "Reordering chromosomes..."
+    fasta_reordered = "%s.%s%s" % (
+        os.path.splitext(os.path.basename(fasta))[0],
+        "karyotypic",
+        os.path.splitext(os.path.basename(fasta))[1])
+    with open(fasta_reordered,'w') as fp:
+        for chrom in chroms:
+            chromfile = os.path.join(wd,"%s.fa" % chrom)
+            print "\t%s (%s)" % (chrom,chromfile)
+            with open(chromfile,'r') as fpp:
+                fp.write(fpp.read())
+    print "Wrote reordered FASTA file to %s" % fasta_reordered
+    print "Finished"

--- a/docs/source/reference/ngs_general.rst
+++ b/docs/source/reference/ngs_general.rst
@@ -11,6 +11,7 @@ General NGS scripts that are used for both ChIP-seq and RNA-seq.
 * :ref:`splitBarcodes`: separate multiple barcodes in SOLiD data
 * :ref:`remove_mispairs`: remove "singleton" reads from paired end fastq
 * :ref:`remove_mispairs`: remove "singleton" reads from paired end fastq
+* :ref:`reorder_fasta`: reorder chromosomes in FASTA file in karyotypic order
 * :ref:`sam2soap`: convert from SAM file to SOAP format
 * :ref:`separate_paired_fastq`: separate F3 and F5 reads from fastq
 * :ref:`split_fasta`: extract individual chromosome sequences from fasta file
@@ -176,6 +177,28 @@ remove_mispairs.py
 Python implementation of ``remove_mispairs.pl`` which can also remove
 singletons for paired end fastq data file where the reads are not
 interleaved.
+
+.. _reorder_fasta:
+
+reorder_fasta.py
+****************
+
+Reorder the chromosome records in a FASTA file into karyotypic order.
+
+Usage::
+
+    reorder_fasta.py INFILE.fa
+
+Reorders the chromosome records from a FASTA file into 'kayrotypic'
+order, e.g.::
+
+    chr1
+    chr2
+    ...
+    chr10
+    chr11
+
+The output FASTA file will be called ``INFILE.karyotypic.fa``.
 
 .. _sam2soap:
 


### PR DESCRIPTION
PR to implement a utility `reorder_fasta.py` which can be used to put the chromosomes in a FASTA file into karyotypic order.

Some background: GATK3 can have problems with inputs where chromosomes are sorted lexographically rather than karyotypically: [Errors about contigs in BAM or VCF files not being properly ordered or sorted](https://software.broadinstitute.org/gatk/documentation/article?id=1328)

"Lexographic" sorting is essentially the ordering you get by sorting by ASCII characters, and gives ordering like:

    chr10
    chr11
    chr1
    chr2
    ...

"Karyotypic" sorting treats the digits as numbers and gives ordering like:

    chr1
    chr2
    ...
    chr10
    chr11

See also Biostars: [Question: Karyotypically Ordered Hg19](https://www.biostars.org/p/9888/)