### PR TITLE
bcftbx/IlluminaData: allow platform to be set explicitly for IlluminaRun

### DIFF
--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -60,23 +60,31 @@ class IlluminaRun:
 
     """
 
-    def __init__(self,illumina_run_dir):
+    def __init__(self,illumina_run_dir,platform=None):
         """Create and populate a new IlluminaRun object
 
         Arguments:
           illumina_run_dir: path to the top-level directory holding
             the 'raw' sequencing data
+          platform: (optional) string specificying the sequencer
+            platform. The platform should be detected automatically
+            so only specify this if the sequencer is not in the
+            list in platforms.py.
 
         """
         # Top-level directory
         self.run_dir = os.path.abspath(illumina_run_dir)
         # Platform
-        self.platform = platforms.get_sequencer_platform(self.run_dir)
+        if platform is None:
+            self.platform = platforms.get_sequencer_platform(self.run_dir)
+        else:
+            self.platform = str(platform)
         if self.platform is None:
-            raise Exception("Can't determine platform for %s" % self.run_dir)
+            raise IlluminaDataPlatformError("Can't determine platform for "
+                                            "%s" % self.run_dir)
         elif self.platform not in KNOWN_PLATFORMS:
-            raise Exception("%s: not a recognised Illumina platform" %
-                            self.run_dir)
+            raise IlluminaDataPlatformError("%s: not a recognised Illumina "
+                                            "platform" % self.run_dir)
         # Basecalls subdirectory
         self.basecalls_dir = os.path.join(self.run_dir,
                                           'Data','Intensities','BaseCalls')
@@ -2398,6 +2406,9 @@ class IlluminaFastq:
 
 class IlluminaDataError(Exception):
     """Base class for errors with Illumina-related code"""
+
+class IlluminaDataPlatformError(IlluminaDataError):
+    """Exception for errors due to platform issues"""
 
 #######################################################################
 # Module Functions

--- a/bcftbx/test/test_IlluminaData.py
+++ b/bcftbx/test/test_IlluminaData.py
@@ -94,6 +94,39 @@ class TestIlluminaRun(unittest.TestCase):
         self.assertEqual(run.lanes,[1,2,3,4])
         self.assertEqual(run.cycles,158)
 
+    def test_illuminarun_unknown_platform(self):
+        # Make a mock run directory for MISeq data with unknown instrument
+        self.mock_illumina_run = MockIlluminaRun(
+            '180329_UNKNOWN0001_0001_000000000-ABCDE1','miseq')
+        self.mock_illumina_run.create()
+        self.assertRaises(IlluminaDataPlatformError,
+                          IlluminaRun,
+                          self.mock_illumina_run.name)
+
+    def test_illuminarun_specify_platform(self):
+        # Make a mock run directory for MISeq data with unknown instrument
+        self.mock_illumina_run = MockIlluminaRun(
+            '180329_UNKNOWN0001_0001_000000000-ABCDE1','miseq')
+        self.mock_illumina_run.create()
+        # Load into an IlluminaRun object
+        run = IlluminaRun(self.mock_illumina_run.name,platform="miseq")
+        # Check the properties
+        self.assertEqual(run.run_dir,self.mock_illumina_run.dirn)
+        self.assertEqual(run.platform,"miseq")
+        self.assertEqual(run.basecalls_dir,
+                         os.path.join(self.mock_illumina_run.dirn,
+                                      'Data','Intensities','BaseCalls'))
+        self.assertEqual(run.sample_sheet_csv,
+                         os.path.join(self.mock_illumina_run.dirn,
+                                      'Data','Intensities','BaseCalls',
+                                      'SampleSheet.csv'))
+        self.assertEqual(run.runinfo_xml,
+                         os.path.join(self.mock_illumina_run.dirn,
+                                      'RunInfo.xml'))
+        self.assertEqual(run.bcl_extension,".bcl")
+        self.assertEqual(run.lanes,[1,])
+        self.assertEqual(run.cycles,218)
+
     def test_illuminarun_miseq_missing_directory(self):
         # Check we can handle IlluminaRun when MISeq directory is missing
         run = IlluminaRun('/does/not/exist/151125_M00879_0001_000000000-ABCDE1')


### PR DESCRIPTION
Address issue #61 by adding an optional `platform` argument to the `IlluminaRun` class in `bcftbx.IlluminaData` module, which overrides the built-in platform-detection (and allows platform to be specified for sequencers with instrument names which aren't listed in `platforms.py`).