### PR TITLE
bcftbx/IlluminaData: update 'fix_bases_mask' for empty barcode sequences

### DIFF
--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -2844,10 +2844,12 @@ def fix_bases_mask(bases_mask,barcode_sequence):
             input_index_length = int(read[1:])
             try:
                 actual_index_length = len(indexes[i])
-                new_read = "I%d" % actual_index_length
             except IndexError:
                 # No barcode for this read
                 actual_index_length = 0
+            if actual_index_length > 0:
+                new_read = "I%d" % actual_index_length
+            else:
                 new_read = ""
             if input_index_length > actual_index_length:
                 # Actual index sequence is shorter so adjust

--- a/bcftbx/test/test_IlluminaData.py
+++ b/bcftbx/test/test_IlluminaData.py
@@ -3394,7 +3394,18 @@ class TestFixBasesMask(unittest.TestCase):
                          'y250,I8,nnnnnnnn,y250')
         self.assertEqual(fix_bases_mask('y250,I8,I8,y250','TAAGGC'),
                          'y250,I6nn,nnnnnnnn,y250')
+
+    def test_fix_bases_mask_single_index_no_barcode(self):
+        """Check fix_bases_mask for single index with no barcode
+        """
+        self.assertEqual(fix_bases_mask('y76,I8,y76',''),
+                         'y76,nnnnnnnn,y76')
         
+    def test_fix_bases_dual_index_no_barcode(self):
+        """Check fix_bases_mask for dual index with no barcode
+        """
+        self.assertEqual(fix_bases_mask('y76,I8,I8,y76',''),
+                         'y76,nnnnnnnn,nnnnnnnn,y76')
 
 class TestSplitRunName(unittest.TestCase):
 


### PR DESCRIPTION
PR to address an issue with the `fix_base_mask` function in `bcftbx/IlluminaData`, when a zero length barcode is supplied (was masking the index reads incorrectly e.g. generating `I0nnnnnn` rather than `nnnnnn`).