### PR TITLE
GEJobRunner: quote script arguments containing whitespace

### DIFF
--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -440,7 +440,11 @@ class GEJobRunner(BaseJobRunner):
         logging.debug("Arguments  : %s" % str(args))
         # Build command to be submitted
         cmd_args = [script]
-        cmd_args.extend(args)
+        for arg in args:
+            # Quote arguments containing whitespace
+            if arg.count(' ') or arg.count('\t'):
+                arg = "\"%s\"" % arg
+            cmd_args.append(arg)
         cmd = ' '.join(cmd_args)
         # Build qsub command to submit it
         qsub = ['qsub','-b','y','-V','-N',name]


### PR DESCRIPTION
PR to fix a bug in the `GEJobRunner` class (in `bcftbx/JobRunner.py` ), when arguments containing whitespace are supplied to the `run` method.

Without this fix the generated command which is sent via `qsub` is incorrectly parsed and will either fail, or not be executed as originally intended.