### PR TITLE
[WIP] Update 'make_macs2_xls.py' to enable additional output BED file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ install:
 script:
 # Run the unit tests for bcftbx
   - "python setup.py test"
+# Run the make_macs2_xls tests
+  - "nosetests --exe -v ChIP-seq/make_macs2_xls.py"
 # Run the fastq_strand tests
   - "nosetests --exe -v QC-pipeline/fastq_strand.py"
 # Run the best_exons example


### PR DESCRIPTION
PR to add a new `--bed` option which outputs a BED-like file with columns `chr`, `abs_summit-100` and `abs_summit+100` in addition to the XLSX file produced by default.