### PR TITLE
illumina_qc.sh: add option to disable Fastq_screen

### DIFF
--- a/QC-pipeline/illumina_qc.sh
+++ b/QC-pipeline/illumina_qc.sh
@@ -247,7 +247,7 @@ program_info=${qc_dir}/${fastq_base%%.fq}.$qc.programs
 echo "# Program versions and paths used for $fastq_base:" > $program_info
 for prog in $required ; do
     report_program_info $prog >> $program_info
-fi
+done
 #
 # Echo to log
 cat $program_info


### PR DESCRIPTION
PR to add a new option `--no-screens` to the `illumina_qc.sh` script, to suppress running of `fastq_screen`.