### PR TITLE
Allow 4 digit years in run names when splitting into DATE, INSTRUMENT etc

### DIFF
--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -2477,7 +2477,8 @@ def split_run_name_full(dirname):
     component is used as the ID.
     """
     fields = os.path.basename(dirname).split('_')
-    if len(fields) > 3 and len(fields[0]) == 6 and fields[0].isdigit:
+    if len(fields) > 3 and fields[0].isdigit and \
+       (len(fields[0]) == 6 or len(fields[0]) == 8):
         date_stamp = fields[0]
     else:
         raise IlluminaDataError("Unable to extract date stamp from "

--- a/bcftbx/test/test_IlluminaData.py
+++ b/bcftbx/test/test_IlluminaData.py
@@ -3449,6 +3449,9 @@ class TestSplitRunNameFull(unittest.TestCase):
             ('120518','ILLUMINA-73D9FA','00002','','FC'))
         self.assertEqual(split_run_name_full('151216_NB500968_0008_AH5CFGAFXX'),
                          ('151216','NB500968','0008','A','H5CFGAFXX'))
+        self.assertEqual(
+            split_run_name_full('20180829_FS10000171_3_BNT40323-1530'),
+                         ('20180829','FS10000171','3','B','NT40323-1530'))
 
     def test_split_run_name_full_with_leading_path(self):
         """Check split_run_name_full with leading path


### PR DESCRIPTION
The `split_run_name_full`  needs to be updated to handle run names which use a full four-digit year in the datestamp, e.g. for the iSeq platform:

    20180829_FS10000171_3_BNT40323-1530