### PR TITLE
Fix fastq_strand.py to handle no mapped reads from STAR

### DIFF
--- a/QC-pipeline/fastq_strand.py
+++ b/QC-pipeline/fastq_strand.py
@@ -625,8 +625,13 @@ def fastq_strand(argv,working_dir=None):
             print "- col2: %d" % sum_col2
             print "- col3: %d" % sum_col3
             print "- col4: %d" % sum_col4
-            forward_1st = float(sum_col3)/float(sum_col2)*100.0
-            reverse_2nd = float(sum_col4)/float(sum_col2)*100.0
+            if sum_col2 > 0.0:
+                forward_1st = float(sum_col3)/float(sum_col2)*100.0
+                reverse_2nd = float(sum_col4)/float(sum_col2)*100.0
+            else:
+                logging.warning("Sum of mapped reads is zero!")
+                forward_1st = 0.0
+                reverse_2nd = 0.0
             print "Strand percentages:"
             print "- 1st forward: %.2f%%" % forward_1st
             print "- 2nd reverse: %.2f%%" % reverse_2nd


### PR DESCRIPTION
PR updating the `fastq_strand.py` utility to handle the case when `STAR` completes successfully but no reads from the input Fastqs are mapped. In this case the total count of mapped reads is zero and this results in a `ZeroDivision` exception from `fastq_strand.py`.

With this update, the program will instead report the forward and reverse psuedo-percentages as both being zero and complete without an error.