### PR TITLE
Fix failure in 'illumina_qc.sh' script using --no-screens option

### DIFF
--- a/QC-pipeline/illumina_qc.sh
+++ b/QC-pipeline/illumina_qc.sh
@@ -315,8 +315,10 @@ fi
 # Update permissions and group (if specified)
 set_permissions_and_group "$SET_PERMISSIONS" "$SET_GROUP" $qc_dir
 set_permissions_and_group "$SET_PERMISSIONS" "$SET_GROUP" "$program_info"
-set_permissions_and_group "$SET_PERMISSIONS" "$SET_GROUP" "$qc_dir/$(get_fastq_basename $FASTQ)_*_screen.*"
 set_permissions_and_group -R "$SET_PERMISSIONS" "$SET_GROUP" "$qc_dir/${fastqc_base}*"
+if [ $do_fastq_screen == "yes" ] ; then
+    set_permissions_and_group "$SET_PERMISSIONS" "$SET_GROUP" "$qc_dir/$(get_fastq_basename $FASTQ)_*_screen.*"
+fi
 #
 echo ILLUMINA QC pipeline completed: `date`
 exit

--- a/QC-pipeline/illumina_qc.sh
+++ b/QC-pipeline/illumina_qc.sh
@@ -4,7 +4,7 @@
 #
 # Usage: illumina_qc.sh <fastq>
 #
-VERSION=1.3.2
+VERSION=1.3.3
 #
 function usage() {
     echo "Usage: $(basename $0) <fastq[.gz]> [options]"


### PR DESCRIPTION
PR which fixes a bug in `QC-pipeline/illumina_qc.sh` when using the `--no-screens` option (which suppresses `fastq_screen` runs). In this case if new permissions were also specified in the `qc.setup` script then `illumina_qc.sh` would fail when trying to set permissions on the missing `fastq_screen` outputs.