### PR TITLE
QC-pipeline/fastq_strand.py: bump version to 0.0.4.

### DIFF
--- a/QC-pipeline/fastq_strand.py
+++ b/QC-pipeline/fastq_strand.py
@@ -4,7 +4,7 @@
 #     Copyright (C) University of Manchester 2017-2018 Peter Briggs
 #
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 
 #######################################################################
 # Imports


### PR DESCRIPTION
PR which bumps version of `fastq_strand.py` to 0.0.4 to mark the changes implemented to handle strandedness edge cases etc in PR #81.