### PR TITLE
GEJobRunner: improve lock on job finalization

### DIFF
--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -820,26 +820,29 @@ exit $exit_code
         logging.debug("GEJobRunner: handle job completion for %s"
                       % job_id)
         # Check job finalization hasn't already been started
-        print "GEJobRunner: attempting to get lock for %s" % job_id
+        logging.debug("GEJobRunner: attempting to get lock for %s"
+                      % job_id)
         lock = "%s@%s" % (job_id,time.time())
-        print "GEJobRunner: try to make new lock: %s" % lock
+        logging.debug("GEJobRunner: try to make new lock: %s"
+                      % lock)
         self.__job_lock[lock] = True
         for name in self.__job_lock:
             if name == lock:
                 continue
-            print "GEJobRunner: -- checking lock: %s" % name
+            logging.debug("GEJobRunner: -- checking existing lock: "
+                          "%s" % name)
             j,t = name.split('@')
             if (int(j) == int(job_id)) and \
                (float(t) < float(lock.split('@')[1])):
                 # Another process already has the lock on
                 # finishing this job, so let that do it
-                print "GEJobRunner: already locked, giving up"
+                logging.debug("GEJobRunner: already locked, giving up")
                 del(self.__job_lock[lock])
                 logging.debug("GEJobRunner: skipping job "
                               "finalization for %s (already "
                               "started elsewhere)" % job_id)
                 return
-        print "GEJobRunner: acquired lock: %s" % lock
+        logging.debug("GEJobRunner: acquired lock: %s" % lock)
         self.__finalizing[job_id] = True
         # Check there is an exit code file
         exit_code_file = os.path.join(self.__admin_dir,

--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -756,6 +756,16 @@ exit $exit_code
         """
         logging.debug("GEJobRunner: removing admin dir '%s'" %
                       self.__admin_dir)
+        # Check if jobs are still being finalized
+        start_time = time.time()
+        while self.__finalizing:
+            # Wait until everything has finalized
+            time.sleep(1.0)
+            if (time.time() - start_time) > self.__ge_timeout:
+                logging.warning("GEJobRunner: timed out waiting "
+                                "for jobs to finalize")
+                break
+        # Try to remove the admin dir and contents
         try:
             shutil.rmtree(self.__admin_dir)
         except Exception as ex:

--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -492,13 +492,14 @@ class GEJobRunner(BaseJobRunner):
         cmd = ' '.join(cmd_args)
         job_script = os.path.join(job_dir,"job_script.sh")
         with open(job_script,'w') as fp:
-            fp.write("""#!%s
-echo "$QUEUE" > %s/__queue
-%s
+            fp.write("""#!{shell}
+echo "$QUEUE" > {job_dir}/__queue
+{cmd}
 exit_code=$?
-echo "$exit_code" > %s/__exit_code
+echo "$exit_code" > {job_dir}/__exit_code.tmp
+mv {job_dir}/__exit_code.tmp {job_dir}/__exit_code
 exit $exit_code
-""" % (self.__shell,job_dir,cmd,job_dir))
+""".format(shell=self.__shell,job_dir=job_dir,cmd=cmd))
         os.chmod(job_script,0755)
         # Sanitize name for GE by replacing invalid characters
         # (colon, asterisk...)

--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -570,8 +570,9 @@ exit $exit_code
         exit_code_file = os.path.join(self.__admin_dir,
                                       str(self.__job_number[job_id]),
                                       "__exit_code")
-        with open(exit_code_file,'w') as fp:
+        with open("%s.tmp" % exit_code_file,'w') as fp:
             fp.write("-1\n")
+        os.rename("%s.tmp" % exit_code_file,exit_code_file)
         # Force update of cached job list
         self.__cached_job_list_force_update = True
         return True

--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -664,18 +664,18 @@ exit $exit_code
                 logging.debug("GEJobRunner: using cached job list")
                 job_ids = self.__cached_job_list
                 # Add the jobs in grace period
-                grace_period_jobs = self.__start_time.keys()
+                grace_period_jobs = list(self.__start_time.keys())
                 for job_id in grace_period_jobs:
                     if job_id not in job_ids:
                         job_ids.append(job_id)
                 return job_ids
         # Update jobs in grace period
-        for job_id in self.__start_time.keys():
+        for job_id in list(self.__start_time.keys()):
             self.__update_job_grace_period(job_id)
-        grace_period_jobs = self.__start_time.keys()
+        grace_period_jobs = list(self.__start_time.keys())
         # Build initial list from directory contents
         job_ids = []
-        for job_id in self.__job_number.keys():
+        for job_id in list(self.__job_number.keys()):
             try:
                 job_number = self.__job_number[job_id]
             except KeyError:
@@ -838,7 +838,7 @@ exit $exit_code
         logging.debug("GEJobRunner: try to make new lock: %s"
                       % lock)
         self.__job_lock[lock] = True
-        for name in self.__job_lock:
+        for name in list(self.__job_lock.keys()):
             if name == lock:
                 continue
             logging.debug("GEJobRunner: -- checking existing lock: "


### PR DESCRIPTION
PR which improves the locking of job finalization in the `GEJobRunner` class - the previous implementation (check a dictionary entry: if the key is not found then create it and assign it as `True`) still exhibits failures due to race conditions.

The reimplementation uses the following procedure:
 
* Create a new lock entry in a dictionary where the key is a combination of the job id, timestamp and unique ID
* Check for any other lock entries where the first part of the key is the same as the job id; if one is found then compare the timestamps
* If the new timestamp is newer than the existing one then the existing lock takes precedence; the new lock is abandoned
* If the new timestamp is older than the existing one then the "new" lock takes precedence
* If the timestamps are identical then abort the lock attempt, wait a random period of time (<1s) and retry the lock.

This updated method seems to be more robust than the previous attempt.