### PR TITLE
bcftbx/IlluminaData: update SampleSheet to handle 'Manifests' section in IEM sample sheet files

### DIFF
--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -1,5 +1,5 @@
 #     IlluminaData.py: module for handling data about Illumina sequencer runs
-#     Copyright (C) University of Manchester 2012-2018 Peter Briggs
+#     Copyright (C) University of Manchester 2012-2019 Peter Briggs
 #
 ########################################################################
 #
@@ -758,6 +758,9 @@ class SampleSheet:
     The 'Settings' section consists of comma-separated key-value
     pairs e.g. 'Adapter,CTGTCTCTTATACACATCT'.
 
+    The 'Manifests' section consists of comma-separated key-filename
+    pairs e.g. 'A,TruSeqAmpliconManifest-1.txt'.
+
     The 'Data' section contains the data about the lanes, samples
     and barcode indexes. It consists of lines of comma-separated
     values, with the first line being a 'header', and the remainder
@@ -812,6 +815,13 @@ class SampleSheet:
     ['ReverseComplement',...]
     >>> iem.settings['ReverseComplement']
     '0'
+
+    To access 'manifests' items:
+
+    >>> iem.manifests_items
+    ['A',...]
+    >>> iem.manifests['A']
+    'TruSeqAmpliconManifest-1.txt'
 
     To access 'data' (the actual sample sheet information):
 
@@ -910,6 +920,7 @@ class SampleSheet:
         self._header = utils.OrderedDictionary()
         self._reads = list()
         self._settings = utils.OrderedDictionary()
+        self._manifests = utils.OrderedDictionary()
         # Store raw data
         self._data = None
         # Read in file contents
@@ -1014,6 +1025,9 @@ class SampleSheet:
             elif section == 'Settings':
                 # Settings lines are comma-separated PARAM,VALUE lines
                 self._set_section_param_value(line,self._settings)
+            elif section == 'Manifests':
+                # Manifests lines are comma-separated PARAM,VALUE lines
+                self._set_section_param_value(line,self._manifests)
             elif section is None:
                 raise IlluminaDataError("Not a valid sample sheet?")
             else:
@@ -1222,6 +1236,34 @@ class SampleSheet:
 
         """
         return self._settings
+
+    @property
+    def manifests_items(self):
+        """
+        Return list of keys listed in the '[Manifests]' section
+
+        If the sample sheet didn't contain a '[Manifests]' section
+        then returns an empty list.
+
+        Returns:
+          List of item names.
+
+        """
+        return self._manifests.keys()
+
+    @property
+    def manifests(self):
+        """
+        Return ordered dictionary for the '[Manifests]' section
+
+        If the sample sheet didn't contain a '[Manifests]' section
+        then returns an empty OrderedDictionary.
+
+        Returns:
+          OrderedDictionary where keys are data items.
+
+        """
+        return self._manifests
 
     @property
     def data(self):

--- a/bcftbx/test/test_IlluminaData.py
+++ b/bcftbx/test/test_IlluminaData.py
@@ -1081,6 +1081,33 @@ Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,ind
 AO1,AO1,,,N701,TAAGGCGA,S517,GCGTAAGA,Anne Other,
 AO2,AO2,,,N701,TAAGGCGA,S502,CTCTCTAT,Anne Other,
 """
+        self.hiseq_sample_sheet_with_manifests = """[Header]
+IEMFileVersion,4
+Investigator Name,Peter B
+Experiment Name,myexp
+Date,1/19/2019
+Workflow,GenerateFASTQ
+Application,FASTQ Only
+Assay,Nextera XT v2 Set A
+Description,NGS_test
+Chemistry,Amplicon
+
+[Manifests]
+A,TruSeqAmpliconManifest-1.txt
+B,TruSeqAmpliconManifest-2.txt
+
+[Reads]
+151
+151
+
+[Settings]
+ReverseComplement,0
+
+[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,PJB1-1579,PJB1-1579,,,N701,CGATGTAT ,N501,TCTTTCCC,PeterBriggs,
+1,PJB2-1580,PJB2-1580,,,N702,TGACCAAT ,N502,TCTTTCCC,PeterBriggs,
+"""
 
     def test_load_hiseq_sample_sheet(self):
         """SampleSheet: load a HiSEQ IEM-format sample sheet
@@ -1650,6 +1677,61 @@ Adapter,CTGTCTCTTATACACATCT
                          "\"Nextera XT Index Kit (96 Indexes, 384 Samples)\"")
         self.assertEqual(iem.header['Description'],"")
         self.assertEqual(iem.header['Chemistry'],"Amplicon")
+
+    def test_load_hiseq_sample_sheet_with_manifests(self):
+        """SampleSheet: load a HiSEQ IEM-format sample sheet with 'Manifests' section
+
+        """
+        iem = SampleSheet(fp=cStringIO.StringIO(
+            self.hiseq_sample_sheet_with_manifests))
+        # Check format
+        self.assertEqual(iem.format,'IEM')
+        # Check header
+        self.assertEqual(iem.header_items,['IEMFileVersion',
+                                           'Investigator Name',
+                                           'Experiment Name',
+                                           'Date',
+                                           'Workflow',
+                                           'Application',
+                                           'Assay',
+                                           'Description',
+                                           'Chemistry'])
+        self.assertEqual(iem.header['IEMFileVersion'],'4')
+        self.assertEqual(iem.header['Investigator Name'],'Peter B')
+        self.assertEqual(iem.header['Experiment Name'],'myexp')
+        self.assertEqual(iem.header['Date'],'1/19/2019')
+        self.assertEqual(iem.header['Workflow'],'GenerateFASTQ')
+        self.assertEqual(iem.header['Application'],'FASTQ Only')
+        self.assertEqual(iem.header['Assay'],'Nextera XT v2 Set A')
+        self.assertEqual(iem.header['Description'],'NGS_test')
+        self.assertEqual(iem.header['Chemistry'],'Amplicon')
+        # Check manifests
+        self.assertEqual(iem.manifests_items,['A','B'])
+        self.assertEqual(iem.manifests['A'],'TruSeqAmpliconManifest-1.txt')
+        self.assertEqual(iem.manifests['B'],'TruSeqAmpliconManifest-2.txt')
+        # Check reads
+        self.assertEqual(iem.reads,['151','151'])
+        # Check settings
+        self.assertEqual(iem.settings_items,['ReverseComplement',])
+        self.assertEqual(iem.settings['ReverseComplement'],'0')
+        # Check data
+        self.assertEqual(iem.data.header(),['Lane','Sample_ID','Sample_Name',
+                                            'Sample_Plate','Sample_Well',
+                                            'I7_Index_ID','index',
+                                            'I5_Index_ID','index2',
+                                            'Sample_Project','Description'])
+        self.assertEqual(len(iem.data),2)
+        self.assertEqual(iem.data[0]['Lane'],1)
+        self.assertEqual(iem.data[0]['Sample_ID'],'PJB1-1579')
+        self.assertEqual(iem.data[0]['Sample_Name'],'PJB1-1579')
+        self.assertEqual(iem.data[0]['Sample_Plate'],'')
+        self.assertEqual(iem.data[0]['Sample_Well'],'')
+        self.assertEqual(iem.data[0]['I7_Index_ID'],'N701')
+        self.assertEqual(iem.data[0]['index'],'CGATGTAT')
+        self.assertEqual(iem.data[0]['I5_Index_ID'],'N501')
+        self.assertEqual(iem.data[0]['index2'],'TCTTTCCC')
+        self.assertEqual(iem.data[0]['Sample_Project'],'PeterBriggs')
+        self.assertEqual(iem.data[0]['Description'],'')
 
 class TestIEMSampleSheet(unittest.TestCase):
     def setUp(self):

--- a/bcftbx/test/test_IlluminaData.py
+++ b/bcftbx/test/test_IlluminaData.py
@@ -1104,9 +1104,9 @@ B,TruSeqAmpliconManifest-2.txt
 ReverseComplement,0
 
 [Data]
-Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
-1,PJB1-1579,PJB1-1579,,,N701,CGATGTAT ,N501,TCTTTCCC,PeterBriggs,
-1,PJB2-1580,PJB2-1580,,,N702,TGACCAAT ,N502,TCTTTCCC,PeterBriggs,
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description,Manifest
+1,PJB1-1579,PJB1-1579,,,N701,CGATGTAT ,N501,TCTTTCCC,PeterBriggs,,A
+1,PJB2-1580,PJB2-1580,,,N702,TGACCAAT ,N502,TCTTTCCC,PeterBriggs,,B
 """
 
     def test_load_hiseq_sample_sheet(self):
@@ -1719,7 +1719,8 @@ Adapter,CTGTCTCTTATACACATCT
                                             'Sample_Plate','Sample_Well',
                                             'I7_Index_ID','index',
                                             'I5_Index_ID','index2',
-                                            'Sample_Project','Description'])
+                                            'Sample_Project','Description',
+                                            'Manifest'])
         self.assertEqual(len(iem.data),2)
         self.assertEqual(iem.data[0]['Lane'],1)
         self.assertEqual(iem.data[0]['Sample_ID'],'PJB1-1579')
@@ -1732,6 +1733,7 @@ Adapter,CTGTCTCTTATACACATCT
         self.assertEqual(iem.data[0]['index2'],'TCTTTCCC')
         self.assertEqual(iem.data[0]['Sample_Project'],'PeterBriggs')
         self.assertEqual(iem.data[0]['Description'],'')
+        self.assertEqual(iem.data[0]['Manifest'],'A')
 
 class TestIEMSampleSheet(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
PR to address issue #86: updates the `SampleSheet` class in `bcftbx/IlluminaData` so that it can handle the 'Manifests' section of IEM sample sheet files.

The sample sheet specification is described here:

https://emea.illumina.com/content/dam/illumina-marketing/documents/products/technotes/sequencing-sheet-format-specifications-technical-note-970-2017-004.pdf

The 'Manifests' section looks like e.g.

    [Manifests]
    A,TruSeqAmpliconManifest-1.txt
    B,TruSeqAmpliconManifest-2.txt

and consists of key,filename pairs.

According to the documentation:

> The Data section should also contain a Manifest column to assign a Manifest to each sample. Each sample can be assigned exactly one Manifest, but different samples may be assigned different Manifests

e.g.

    [Data]
    Sample_ID,Sample_Name,I7_Index_ID,index,I5_Index_ID,index2,Manifest,GenomeFolder