### PR TITLE
Update GEJobRunner name sanitisation to handle job names starting with digits

### DIFF
--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -1093,8 +1093,12 @@ exit $exit_code
         """Internal: sanitize a name for use with GE
         """
         ge_name = str(name)
-        for c in ":*":
+        for c in ":*@\?":
             ge_name = ge_name.replace(c,'_')
+        if ge_name[0].isdigit():
+            # Name cannot start with a digit so
+            # prepend an underscore
+            ge_name = "_%s" % ge_name
         return ge_name
 
 class DRMAAJobRunner(BaseJobRunner):


### PR DESCRIPTION
Grid Engine doesn't allow job names to start with a digit, so this PR updates the job name sanitisation in the `GEJobRunner` class to add an underscore if this is the case.

The PR also updates the list of characters that are sanitised to include `@`, `/` and `?`.