### PR TITLE
Fix bug when updating grace period in GEJobRunner

### DIFF
--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -801,6 +801,7 @@ exit $exit_code
             logging.warning("GEJobRunner: update grace period: job %s "
                             "has gone away (ignored)" % job_id)
             self.__updating_grace_period.release(lock)
+            return
         if ((time.time() - start_time) > self.__new_job_grace_period):
             # Job no longer in grace period
             logging.debug("GEJobRunner: job %s no longer in grace "

--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -798,8 +798,8 @@ exit $exit_code
         try:
             start_time = self.__start_time[job_id]
         except KeyError:
-            logging.warning("GEJobRunner: update grace period: job %s "
-                            "has gone away (ignored)" % job_id)
+            logging.debug("GEJobRunner: update grace period: job %s "
+                          "has gone away (ignored)" % job_id)
             self.__updating_grace_period.release(lock)
             return
         if ((time.time() - start_time) > self.__new_job_grace_period):
@@ -809,9 +809,9 @@ exit $exit_code
             try:
                 del(self.__start_time[job_id])
             except KeyError:
-                logging.warning("GEJobRunner: update grace period: "
-                                "job %s has gone away (ignored)" %
-                                job_id)
+                logging.debug("GEJobRunner: update grace period: "
+                              "job %s has gone away (ignored)" %
+                              job_id)
         # Release update lock
         self.__updating_grace_period.release(lock)
 


### PR DESCRIPTION
PR to fix bug introduced in the `GEJobRunner` class (in `bcftbx/JobRunner`) from previous PR #90, which breaks updating job grace periods in certain circumstances.