### PR TITLE
bcftbx/cmdparse: fixes and updates to move to argparse

### DIFF
--- a/bcftbx/cmdparse.py
+++ b/bcftbx/cmdparse.py
@@ -384,10 +384,7 @@ def add_arg(p,*args,**kwds):
     the parser.
 
     Arguments:
-      p (Object): parser instance; can be an instance
-        of one of: optparse.OptionContainer (i.e.
-        OptionParser or OptionGroup), or
-        argparse.ArgumentParser
+      p (Object): parser instance
       args (List): list of argument values to pass
         directly to the argument-addition method
       kwds (mapping): keyword-value mapping to pass

--- a/bcftbx/cmdparse.py
+++ b/bcftbx/cmdparse.py
@@ -14,14 +14,12 @@ command.
 
 The CommandParser can support arbitrary 'subparser backends' which are
 created to parse the ARGS list for each defined COMMAND. The default
-subparser is the 'optparse.OptionParser' class, but this can be swapped
-for arbitrary subparser (for example, the 'argparse.ArgumentParser'
-class) when the CommandParser is created.
+subparser is the 'argparse.ArgumentParser' class, but this can be swapped
+for arbitrary subparser when the CommandParser is created.
 
 In addition to the core CommandParser class, there are a number of
-supporting functions that can be used with any optparse- or
-argparse-based parser instance, to add the following 'standard'
-options:
+supporting functions that can be used with any argparse-based parser
+instance, to add the following 'standard' options:
 
 * --nprocessors
 * --runner
@@ -39,7 +37,6 @@ __version__ = "1.0.2"
 
 import os
 import sys
-import optparse
 import argparse
 from utils import OrderedDictionary
 
@@ -60,7 +57,7 @@ class CommandParser(object):
 
     Usage:
 
-    Create a simple CommandParser which uses optparse.OptionParser as
+    Create a simple CommandParser which uses argparse.ArgumentParser as
     the default subparser backend using:
 
     >>> p = CommandParser()
@@ -94,7 +91,7 @@ class CommandParser(object):
     """
     def __init__(self,description=None,version=None,subparser=None):
         """Create a command line parser
-        with 'subparser' as the backend (default=OptionParser)
+        with 'subparser' as the backend (default=ArgumentParser)
         This parser can process command lines of the form
 
         PROG CMD OPTIONS ARGS
@@ -109,7 +106,7 @@ class CommandParser(object):
         self._commands = OrderedDictionary()
         self._help = dict()
         if not subparser:
-            subparser = optparse.OptionParser
+            subparser = argparse.ArgumentParser
         self._subparser = subparser
 
     def add_command(self,cmd,help=None,**args):

--- a/bcftbx/cmdparse.py
+++ b/bcftbx/cmdparse.py
@@ -29,7 +29,7 @@ instance, to add the following 'standard' options:
 
 """
 
-__version__ = "1.0.2"
+__version__ = "2.0.0"
 
 #######################################################################
 # Imports

--- a/bcftbx/cmdparse.py
+++ b/bcftbx/cmdparse.py
@@ -135,6 +135,9 @@ class CommandParser(object):
         """
         if cmd in self._commands:
             raise Exception("Command '%s' already defined" % cmd)
+        if 'prog' not in args:
+            args['prog'] = "%s %s" % (os.path.basename(sys.argv[0]),
+                                      cmd)
         if 'version' not in args:
             args['version'] = self._version
         p = self._subparser(**args)

--- a/bcftbx/cmdparse.py
+++ b/bcftbx/cmdparse.py
@@ -394,10 +394,9 @@ def add_arg(p,*args,**kwds):
         directly to the argument-addition method
 
     """
-    if isinstance(p,argparse.ArgumentParser):
-        add_arg = p.add_argument
-    elif isinstance(p,optparse.OptionContainer):
-        add_arg = p.add_option
-    else:
-        raise Exception("Unrecognised subparser class")
-    return add_arg(*args,**kwds)
+    for add_arg in ('add_argument','add_option',):
+        try:
+            return getattr(p,add_arg)(*args,**kwds)
+        except AttributeError:
+            pass
+    raise Exception("Unrecognised subparser class")

--- a/bcftbx/test/test_cmdparse.py
+++ b/bcftbx/test/test_cmdparse.py
@@ -221,3 +221,11 @@ class TestAddOptionFunctions(unittest.TestCase):
         add_arg(p,'-n',action='store',dest='n')
         args = p.parse_args(['-n','4'])
         self.assertEqual(args.n,'4')
+    def test_add_arg_with_argumentparser(self):
+        """add_arg works with ArgumentParser argument group
+        """
+        p = ArgumentParser()
+        g = p.add_argument_group('Suboptions')
+        add_arg(g,'-n',action='store',dest='n')
+        args = p.parse_args(['-n','4'])
+        self.assertEqual(args.n,'4')

--- a/bcftbx/test/test_cmdparse.py
+++ b/bcftbx/test/test_cmdparse.py
@@ -3,10 +3,20 @@
 #######################################################################
 
 import unittest
-from optparse import OptionParser
-from optparse import OptionGroup
 from argparse import ArgumentParser
-from bcftbx.cmdparse import *
+try:
+    from optparse import OptionParser
+    from optparse import OptionGroup
+    OPTPARSE_AVAILABLE = True
+except ImportError:
+    OPTPARSE_AVAILABLE = False
+from bcftbx.cmdparse import CommandParser
+from bcftbx.cmdparse import add_nprocessors_option
+from bcftbx.cmdparse import add_runner_option
+from bcftbx.cmdparse import add_no_save_option
+from bcftbx.cmdparse import add_dry_run_option
+from bcftbx.cmdparse import add_debug_option
+from bcftbx.cmdparse import add_arg
 
 class TestCommandParserOptionParser(unittest.TestCase):
     """Tests for CommandParser using default OptionParser backend
@@ -14,14 +24,20 @@ class TestCommandParserOptionParser(unittest.TestCase):
     def test_add_command(self):
         """CommandParser.add_command works for a single command using optparse
         """
-        p = CommandParser()
+        # Skip the test if optparse not available
+        if not OPTPARSE_AVAILABLE:
+            raise unittest.SkipTest("'optparse' not available")
+        p = CommandParser(subparser=OptionParser)
         cmd = p.add_command('slow')
         self.assertTrue(isinstance(cmd,OptionParser))
         self.assertEqual(p.list_commands(),['slow'])
     def test_add_multiple_commands(self):
         """CommandParser.add_command works for multiple commands using optparse
         """
-        p = CommandParser()
+        # Skip the test if optparse not available
+        if not OPTPARSE_AVAILABLE:
+            raise unittest.SkipTest("'optparse' not available")
+        p = CommandParser(subparser=OptionParser)
         slow_cmd = p.add_command('slow')
         fast_cmd = p.add_command('fast')
         medium_cmd = p.add_command('medium')
@@ -32,7 +48,10 @@ class TestCommandParserOptionParser(unittest.TestCase):
     def test_parser_for(self):
         """CommandParser.parser_for returns the correct OptionParser
         """
-        p = CommandParser()
+        # Skip the test if optparse not available
+        if not OPTPARSE_AVAILABLE:
+            raise unittest.SkipTest("'optparse' not available")
+        p = CommandParser(subparser=OptionParser)
         slow_cmd = p.add_command('slow')
         fast_cmd = p.add_command('fast')
         medium_cmd = p.add_command('medium')
@@ -42,7 +61,10 @@ class TestCommandParserOptionParser(unittest.TestCase):
     def test_parse_args(self):
         """CommandParser.parse_args works for simple cases using optparse
         """
-        p = CommandParser()
+        # Skip the test if optparse not available
+        if not OPTPARSE_AVAILABLE:
+            raise unittest.SkipTest("'optparse' not available")
+        p = CommandParser(subparser=OptionParser)
         slow_cmd = p.add_command('slow')
         fast_cmd = p.add_command('fast')
         slow_cmd.add_option('-a',action='store',dest='a_value')
@@ -132,6 +154,9 @@ class TestAddOptionFunctions(unittest.TestCase):
     def test_add_nprocessors_option(self):
         """add_nprocessors_option enables '--nprocessors'
         """
+        # Skip the test if optparse not available
+        if not OPTPARSE_AVAILABLE:
+            raise unittest.SkipTest("'optparse' not available")
         p = OptionParser()
         add_nprocessors_option(p,1)
         options,args = p.parse_args(['--nprocessors','4'])
@@ -146,6 +171,9 @@ class TestAddOptionFunctions(unittest.TestCase):
     def test_add_runner_option(self):
         """add_runner_option enables '--runner'
         """
+        # Skip the test if optparse not available
+        if not OPTPARSE_AVAILABLE:
+            raise unittest.SkipTest("'optparse' not available")
         p = OptionParser()
         add_runner_option(p)
         options,args = p.parse_args(['--runner','SimpleJobRunner'])
@@ -160,6 +188,9 @@ class TestAddOptionFunctions(unittest.TestCase):
     def test_add_no_save_option(self):
         """add_no_save_option enables '--no-save'
         """
+        # Skip the test if optparse not available
+        if not OPTPARSE_AVAILABLE:
+            raise unittest.SkipTest("'optparse' not available")
         p = OptionParser()
         add_no_save_option(p)
         options,args = p.parse_args(['--no-save'])
@@ -174,6 +205,9 @@ class TestAddOptionFunctions(unittest.TestCase):
     def test_add_dry_run_option(self):
         """add_dry_run_option enables '--dry-run'
         """
+        # Skip the test if optparse not available
+        if not OPTPARSE_AVAILABLE:
+            raise unittest.SkipTest("'optparse' not available")
         p = OptionParser()
         add_dry_run_option(p)
         options,args = p.parse_args(['--dry-run'])
@@ -188,6 +222,9 @@ class TestAddOptionFunctions(unittest.TestCase):
     def test_add_debug_option(self):
         """add_debug_option enables '--debug'
         """
+        # Skip the test if optparse not available
+        if not OPTPARSE_AVAILABLE:
+            raise unittest.SkipTest("'optparse' not available")
         p = OptionParser()
         add_debug_option(p)
         options,args = p.parse_args(['--debug'])
@@ -202,6 +239,9 @@ class TestAddOptionFunctions(unittest.TestCase):
     def test_add_arg_with_optionparser(self):
         """add_arg works with OptionParser
         """
+        # Skip the test if optparse not available
+        if not OPTPARSE_AVAILABLE:
+            raise unittest.SkipTest("'optparse' not available")
         p = OptionParser()
         add_arg(p,'-n',action='store',dest='n')
         options,args = p.parse_args(['-n','4'])
@@ -209,6 +249,9 @@ class TestAddOptionFunctions(unittest.TestCase):
     def test_add_arg_with_optiongroup(self):
         """add_arg works with OptionGroup
         """
+        # Skip the test if optparse not available
+        if not OPTPARSE_AVAILABLE:
+            raise unittest.SkipTest("'optparse' not available")
         p = OptionParser()
         g = OptionGroup(p,'Suboptions')
         add_arg(g,'-n',action='store',dest='n')


### PR DESCRIPTION
PR which updates the `bcftbx/cmdparse` module so that it no longer depends explicitly on the deprecated `optparse` library. Instead the `argparse.ArgumentParser` is used as the default parser class from now on.

(This PR should address the outstanding parts of issues #46 and #68.)