### PR TITLE
Fix parser conflict for -v option in 'prep_sample_sheet.py' utility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ install:
 script:
 # Run the unit tests for bcftbx
   - "python setup.py test"
+# Run the illumina2cluster tests
+  - ./illumina2cluster/prep_sample_sheet.py -h
 # Run the RNA-seq utility tests
   - "nosetests --exe -v RNA-seq/bowtie_mapping_stats.py"
   - ./RNA-seq/examples/test_bowtie_mapping_stats.sh

--- a/illumina2cluster/prep_sample_sheet.py
+++ b/illumina2cluster/prep_sample_sheet.py
@@ -103,7 +103,7 @@ if __name__ == "__main__":
                    help="specify the format of the output sample sheet "
                    "written by the -o option; can be either 'CASAVA' or "
                    "'IEM' (defaults to the format of the original file)")
-    p.add_argument('-v','--view',action="store_true",dest="view",
+    p.add_argument('-V','--view',action="store_true",dest="view",
                    help="view predicted outputs from sample sheet")
     p.add_argument('--fix-spaces',action="store_true",dest="fix_spaces",
                    help="replace spaces in sample ID and project fields "


### PR DESCRIPTION
PR which fixes a bug in the `illumina2cluster/prep_sample_sheet.py` utility, introduced by the switch to `argparse` - the `-v` option is defined twice as shorthand for the implicit `--version` option as well as for the `--view` option. This change updates the shorthand for `--view` to be `-V`.