### PR TITLE
'bcftbx/Spreadsheet': fix exception capturing syntax

### DIFF
--- a/bcftbx/Spreadsheet.py
+++ b/bcftbx/Spreadsheet.py
@@ -699,7 +699,7 @@ class Styles(object):
                 easyxf_style += '; '
         try:
             xf_style = easyxf(easyxf_style,num_format_str=num_format_str)
-        except xlwt.Style.EasyXFCallerError, ex:
+        except xlwt.Style.EasyXFCallerError as ex:
             logging.warning("Unable to get style: '%s'" % ex)
             xf_style = easyxf()
         # Store and return


### PR DESCRIPTION
PR to fix the syntax for capturing an exception, for Python 3 compatibility.