### PR TITLE
bcftbx/JobRunner: SimpleJobRunner.list() should trap for 'missing' jobs

### DIFF
--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -308,7 +308,12 @@ class SimpleJobRunner(BaseJobRunner):
         """
         job_ids = []
         for job_id in [jid for jid in self.__job_popen]:
-            p = self.__job_popen[job_id]
+            try:
+                p = self.__job_popen[job_id]
+            except KeyError:
+                # Job has been removed since the list
+                # was fetched? Ignore
+                continue
             status = p.poll()
             if status is None:
                 job_ids.append(job_id)


### PR DESCRIPTION
PR which addresses an intermittent bug in the `SimpleJobRunner` class, when trying to access info on a job which has been removed.

It's unclear what triggers the bug but I'm speculating that it's due to a race condition when the class is used in a threaded context (for example, within the `simple_scheduler` module from the `auto_process_ngs` package).