### PR TITLE
Fix leading zeroes on octal numbers for Python3 compatibility

### DIFF
--- a/QC-pipeline/fastq_strand.py
+++ b/QC-pipeline/fastq_strand.py
@@ -169,14 +169,14 @@ export PYTHONPATH=%s:$PYTHONPATH
 python -c "import sys ; from fastq_strand import mockSTAR ; mockSTAR(sys.argv[1:],unmapped_output=%s)" $@
 exit $?
 """ % (os.path.dirname(__file__),unmapped_output))
-        os.chmod(path,0775)
+        os.chmod(path,0o775)
     def _make_failing_mock_star(self,path):
         # Make a failing mock STAR executable
         with io.open(path,'wt') as fp:
             fp.write(u"""#!/bin/bash
 exit 1
 """)
-        os.chmod(path,0775)
+        os.chmod(path,0o775)
     def test_fastq_strand_one_genome_index_SE(self):
         """
         fastq_strand: test with single genome index (SE)

--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -498,7 +498,7 @@ echo "$exit_code" > {job_dir}/__exit_code.tmp
 mv {job_dir}/__exit_code.tmp {job_dir}/__exit_code
 exit $exit_code
 """.format(shell=self.__shell,job_dir=job_dir,cmd=cmd))
-        os.chmod(job_script,0755)
+        os.chmod(job_script,0o755)
         # Sanitize name for GE by replacing invalid characters
         # (colon, asterisk...)
         ge_name = self.__ge_name(name)

--- a/bcftbx/mockGE.py
+++ b/bcftbx/mockGE.py
@@ -213,7 +213,7 @@ QUEUE=%s %s
 exit_code=$?
 echo "$exit_code" > %s/__exit_code.%d
 """ % (self._shell,queue,command,self._database_dir,job_id))
-            os.chmod(script_file,0775)
+            os.chmod(script_file,0o775)
             # Run the command
             p = subprocess.Popen(script_file,
                                  cwd=working_dir,
@@ -651,7 +651,7 @@ import sys
 from bcftbx.mockGE import MockGE
 sys.exit(MockGE(%s).%s(sys.argv[1:]))
 """ % (','.join(args),f))
-    os.chmod(path,0775)
+    os.chmod(path,0o775)
 
 def setup_mock_GE(bindir=None,database_dir=None,debug=None,
                   qsub_delay=None,qacct_delay=None):

--- a/bcftbx/test/test_utils.py
+++ b/bcftbx/test/test_utils.py
@@ -178,22 +178,22 @@ class TestPathInfo(unittest.TestCase):
         self.example_dir.add_file("group_unreadable.txt")
         self.example_dir.add_file("group_unwritable.txt")
         self.example_dir.add_file("program.exe")
-        os.chmod(self.example_dir.path("spider.txt"),0664)
-        os.chmod(self.example_dir.path("web"),0775)
-        os.chmod(self.example_dir.path("unreadable.txt"),0044)
-        os.chmod(self.example_dir.path("group_unreadable.txt"),0624)
-        os.chmod(self.example_dir.path("group_unwritable.txt"),0644)
-        os.chmod(self.example_dir.path("program.exe"),0755)
+        os.chmod(self.example_dir.path("spider.txt"),0o664)
+        os.chmod(self.example_dir.path("web"),0o775)
+        os.chmod(self.example_dir.path("unreadable.txt"),0o044)
+        os.chmod(self.example_dir.path("group_unreadable.txt"),0o624)
+        os.chmod(self.example_dir.path("group_unwritable.txt"),0o644)
+        os.chmod(self.example_dir.path("program.exe"),0o755)
         self.example_dir.add_link("program","program.exe")
 
     def tearDown(self):
         """Remove directory with test data
 
         """
-        os.chmod(self.example_dir.path("unreadable.txt"),0644)
-        os.chmod(self.example_dir.path("group_unreadable.txt"),0644)
-        os.chmod(self.example_dir.path("group_unwritable.txt"),0644)
-        os.chmod(self.example_dir.path("program.exe"),0644)
+        os.chmod(self.example_dir.path("unreadable.txt"),0o644)
+        os.chmod(self.example_dir.path("group_unreadable.txt"),0o644)
+        os.chmod(self.example_dir.path("group_unwritable.txt"),0o644)
+        os.chmod(self.example_dir.path("program.exe"),0o644)
         self.example_dir.delete_directory()
 
     def test_path(self):
@@ -378,7 +378,7 @@ class TestPathInfo(unittest.TestCase):
         """
         path = PathInfo(self.example_dir.path("spider.txt"))
         # Ensure file can be removed by anyone i.e. write permission for all
-        os.chmod(self.example_dir.path("spider.txt"),0666)
+        os.chmod(self.example_dir.path("spider.txt"),0o666)
         # Will always fail for non-root user?
         current_user = pwd.getpwuid(os.getuid()).pw_name
         if current_user != "root":
@@ -654,9 +654,9 @@ class TestMkdirFunction(unittest.TestCase):
         """
         new_dir = os.path.join(self.test_dir,"new_dir")
         self.assertFalse(os.path.exists(new_dir))
-        mkdir(new_dir,mode=0644)
+        mkdir(new_dir,mode=0o644)
         self.assertTrue(os.path.exists(new_dir))
-        self.assertEqual(stat.S_IMODE(os.lstat(new_dir).st_mode),0644)
+        self.assertEqual(stat.S_IMODE(os.lstat(new_dir).st_mode),0o644)
 
     def test_mkdir_dir_already_exists(self):
         """mkdir: try to make a subdirectory that already exists
@@ -706,20 +706,20 @@ class TestChmodFunction(unittest.TestCase):
         """
         test_file = os.path.join(self.test_dir,'test.txt')
         io.open(test_file,'wt').write(u"Some random text")
-        chmod(test_file,0644)
-        self.assertEqual(stat.S_IMODE(os.lstat(test_file).st_mode),0644)
-        chmod(test_file,0755)
-        self.assertEqual(stat.S_IMODE(os.lstat(test_file).st_mode),0755)
+        chmod(test_file,0o644)
+        self.assertEqual(stat.S_IMODE(os.lstat(test_file).st_mode),0o644)
+        chmod(test_file,0o755)
+        self.assertEqual(stat.S_IMODE(os.lstat(test_file).st_mode),0o755)
 
     def test_chmod_for_directory(self):
         """Check chmod works on a directory
         """
         test_dir = os.path.join(self.test_dir,'test')
         os.mkdir(test_dir)
-        chmod(test_dir,0755)
-        self.assertEqual(stat.S_IMODE(os.lstat(test_dir).st_mode),0755)
-        chmod(test_dir,0777)
-        self.assertEqual(stat.S_IMODE(os.lstat(test_dir).st_mode),0777)
+        chmod(test_dir,0o755)
+        self.assertEqual(stat.S_IMODE(os.lstat(test_dir).st_mode),0o755)
+        chmod(test_dir,0o777)
+        self.assertEqual(stat.S_IMODE(os.lstat(test_dir).st_mode),0o777)
 
     def test_chmod_doesnt_follow_link(self):
         """Check chmod doesn't follow symbolic links
@@ -728,11 +728,11 @@ class TestChmodFunction(unittest.TestCase):
         io.open(test_file,'w').write(u"Some random text")
         test_link = os.path.join(self.test_dir,'test.lnk')
         os.symlink(test_file,test_link)
-        chmod(test_file,0644)
-        self.assertEqual(stat.S_IMODE(os.lstat(test_file).st_mode),0644)
-        chmod(test_link,0755)
+        chmod(test_file,0o644)
+        self.assertEqual(stat.S_IMODE(os.lstat(test_file).st_mode),0o644)
+        chmod(test_link,0o755)
         # Target should be unaffected
-        self.assertEqual(stat.S_IMODE(os.lstat(test_file).st_mode),0644)
+        self.assertEqual(stat.S_IMODE(os.lstat(test_file).st_mode),0o644)
 
 class TestTouchFunction(unittest.TestCase):
     """Unit tests for the 'touch' function


### PR DESCRIPTION
PR to fix leading zeroes on octal numbers e.g. `0755`, which is valid for Python2 but not for Python3 (as numbers cannot have leading zeroes, they result in `SyntaxError: invalid token`).

The correct format is e.g. `0o755`, which is valid for both Python2 and 3.