### PR TITLE
bcftbx/utils: fix Python indentation error

### DIFF
--- a/bcftbx/utils.py
+++ b/bcftbx/utils.py
@@ -599,7 +599,7 @@ def mkdir(dirn,mode=None,recursive=False):
         exist
     """
     if os.path.exists(dirn):
-	return
+        return
     if recursive:
         parent = os.path.dirname(dirn)
         if not os.path.exists(parent):


### PR DESCRIPTION
PR which fixes a Python indentation error in the `bcftbx/utils` module (had a tab character rather than spaces).