### PR TITLE
bcftbx: fix various relative imports which break under Python 3

### DIFF
--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -22,10 +22,10 @@ import os
 import logging
 import xml.dom.minidom
 import shutil
-import platforms
-import utils
-import TabFile
 import io
+from . import platforms
+from . import utils
+from . import TabFile
 from builtins import str
 
 #######################################################################

--- a/bcftbx/cmdparse.py
+++ b/bcftbx/cmdparse.py
@@ -38,7 +38,7 @@ __version__ = "2.0.0"
 import os
 import sys
 import argparse
-from utils import OrderedDictionary
+from .utils import OrderedDictionary
 
 #######################################################################
 # Classes

--- a/bcftbx/platforms.py
+++ b/bcftbx/platforms.py
@@ -16,7 +16,7 @@ Utilities and data to identify NGS sequencer platforms
 """
 
 # Dictionary of sequencer platforms
-from utils import OrderedDictionary
+from .utils import OrderedDictionary
 PLATFORMS = OrderedDictionary()
 PLATFORMS['solid4'] = "SOLiD 4"
 PLATFORMS['solid5500'] = "SOLiD 5500"

--- a/bcftbx/simple_xls.py
+++ b/bcftbx/simple_xls.py
@@ -119,9 +119,9 @@ from builtins import str
 import re
 from collections import Iterator
 import logging
-import Spreadsheet
 import xlsxwriter
-from utils import OrderedDictionary
+from . import Spreadsheet
+from .utils import OrderedDictionary
 
 #######################################################################
 # Constants


### PR DESCRIPTION
PR which fixes the syntax for a number of relative imports in the `bcftbx` library which break when tested under Python 3.