### PR TITLE
bcftbx/FASTQFile: update FastqIterator to be compatible with Python3

### DIFF
--- a/bcftbx/FASTQFile.py
+++ b/bcftbx/FASTQFile.py
@@ -103,7 +103,7 @@ class FastqIterator(Iterator):
         self._lines = []
         self._ip = 0
 
-    def next(self):
+    def __next__(self):
         """Return next record from FASTQ file as a FastqRead object
         """
         # Convenience variables
@@ -145,6 +145,12 @@ class FastqIterator(Iterator):
         self._buf = buf
         self._ip = ip
         return FastqRead(*read)
+
+    def next(self):
+        """
+        Implemented for Python2 compatibility
+        """
+        return self.__next__()
 
 class FastqRead(object):
     """Class to store a FASTQ record with information about a read


### PR DESCRIPTION
PR which refactors the `FastqIterator` class in `bcftbx/FASTQFile` to be compatible with both Python 2 and 3, by renaming the existing `next` method to `__next__` (required for Python3) and reimplementing `next` (required for Python2) as wrapper for `__next__`.

Without this update attempts to instantiate `FastqIterator` under Python3 result in

    TypeError: Can't instantiate abstract class FastqIterator with abstract methods __next__