### PR TITLE
bcftbx/TabFile: update the unit tests for compatibility with Python3

### DIFF
--- a/bcftbx/test/test_TabFile.py
+++ b/bcftbx/test/test_TabFile.py
@@ -9,6 +9,10 @@ import tempfile
 import os
 import shutil
 
+# Import long int for Python3 backwards
+# compatibility with Python2
+from past.builtins import long
+
 class TestTabFile(unittest.TestCase):
 
     def setUp(self):
@@ -622,10 +626,15 @@ chr2\t1234\t5678\t6.8
         self.assertEqual(tabfile.nColumns(),4)
         self.assertEqual(tabfile.header(),['chr','start','end','data'])
         # Divide data column by 10
-        tabfile.transformColumn('data',lambda x: x/10)
+        tabfile.transformColumn('data',lambda x: x/10.0)
         results = [0.46,0.57,0.68]
         for i in range(len(tabfile)):
-            self.assertEqual(tabfile[i]['data'],results[i])
+            # When checking the transformed column, coerce
+            # the values to two decimal places to avoid tests
+            # failing because of rounding errors (e.g.
+            # 0.45999999999999996 != 0.46)
+            self.assertEqual(float("%.2f" % tabfile[i]['data']),
+                             results[i])
 
     def test_compute_midpoint(self):
         """Compute the midpoint of the start and end columns


### PR DESCRIPTION
PR which makes minor updates to a couple of the unit tests for the `bcftbx/TabFile` module so that they work with both Python 2 and 3.

The updates are:

* Import long int type (as this doesn't exist in Python3)
* Refactor test which compares float values (to avoid test failures due to rounding errors)