### PR TITLE
Update bcftbx/TabFile classes to handle underscores in numeric literals (PEP 515)

### DIFF
--- a/bcftbx/test/test_TabFile.py
+++ b/bcftbx/test/test_TabFile.py
@@ -487,6 +487,28 @@ chr2\t1234\t6.8
             for value in line:
                 self.assertEqual(value,str(value))
 
+    def test_convert_values_to_type_handle_underscores_in_numbers(self):
+        """Handle conversion of numeric values with underscores
+        """
+        fp = io.StringIO(
+            u"""chr\tstart\tend
+chr1\t1_012\t4_292.6
+""")
+        tabfile = TabFile('test',fp,first_line_is_header=True,
+                          convert=True,
+                          allow_underscores_in_numeric_literals=True)
+        self.assertEqual(tabfile[0]['start'],1012)
+        self.assertEqual(tabfile[0]['end'],4292.6)
+        fp = io.StringIO(
+            u"""chr\tstart\tend
+chr1\t1_012\t4_292.6
+""")
+        tabfile = TabFile('test',fp,first_line_is_header=True,
+                          convert=True,
+                          allow_underscores_in_numeric_literals=False)
+        self.assertEqual(tabfile[0]['start'],"1_012")
+        self.assertEqual(tabfile[0]['end'],"4_292.6")
+
 class TestBadTabFile(unittest.TestCase):
     """Test with 'bad' input files
     """


### PR DESCRIPTION
PR which updates the `bcftbxTabFile` classes (`TabFile` and `TabDataLine`) to give the option of observing Python PEP 515 (https://www.python.org/dev/peps/pep-0515/) and treat numbers with underscore characters as valid integers or floats (e.g. `1_000` or `4_283.7`).

By default PEP 515 is *not* observed (to preserve the current behaviour) so if these values are encountered then they will not be treated as numerical values. The PR enforces this for both Python 2 and 3.

By setting the `allow_underscores_in_numerical_literals` argument, PEP 515 compatibility is turned on for both Python 2 and 3 (so the behaviour is consistent between Python versions), and these values are converted to the appropriate numerical type.