### PR TITLE
bcftbx/utils: fixes for Python 2/3 compatibility

### DIFF
--- a/bcftbx/test/test_utils.py
+++ b/bcftbx/test/test_utils.py
@@ -147,7 +147,7 @@ AAF#FJJJJJJJJJJJ
         """
         # Make an example file
         example_file = os.path.join(self.wd,"example.txt")
-        with io.open(example_file,'w') as fp:
+        with io.open(example_file,'wt') as fp:
             fp.write(self.example_text)
         # Read lines
         lines = getlines(example_file)
@@ -158,7 +158,7 @@ AAF#FJJJJJJJJJJJ
         """
         # Make an example gzipped file
         example_file = os.path.join(self.wd,"example.txt.gz")
-        with gzip.open(example_file,'w') as fp:
+        with gzip.open(example_file,'wt') as fp:
             fp.write(self.example_text)
         # Read lines
         lines = getlines(example_file)
@@ -1031,9 +1031,11 @@ NATAAATCACCTCACTTAAGTGGCTGGAGACAAATA
     def make_fastq_file(self,fastq,data):
         # Create a fastq file for the testing
         if os.path.splitext(fastq)[1] != '.gz':
-            io.open(fastq,'wt').write(data)
+            with io.open(fastq,'wt') as fp:
+                fp.write(data)
         else:
-            gzip.GzipFile(fastq,'wt').write(data)
+            with gzip.open(fastq,'wt') as fp:
+                fp.write(data)
 
     def test_concatenate_fastq_files(self):
         self.fastq1 = "concat.unittest.1.fastq"
@@ -1058,7 +1060,7 @@ NATAAATCACCTCACTTAAGTGGCTGGAGACAAATA
                                 [self.fastq1,self.fastq2],
                                 overwrite=True,
                                 verbose=False)
-        merged_fastq_data = gzip.GzipFile(self.merged_fastq,'r').read()
+        merged_fastq_data = gzip.open(self.merged_fastq,'rt').read()
         self.assertEqual(merged_fastq_data,self.fastq_data1+self.fastq_data2)
 
 class TestFindProgram(unittest.TestCase):

--- a/bcftbx/test/test_utils.py
+++ b/bcftbx/test/test_utils.py
@@ -8,7 +8,8 @@ import tempfile
 import shutil
 import gzip
 import pickle
-import bcftbx.test.mock_data as mock_data
+from . import mock_data
+from .mock_data import ExampleDirSpiders
 from bcftbx.utils import *
 
 class TestAttributeDictionary(unittest.TestCase):
@@ -797,7 +798,6 @@ class TestFormatFileSize(unittest.TestCase):
         self.assertEqual("0.0T",format_file_size(195035136,units='T'))
         self.assertEqual("0.2T",format_file_size(171798691900,units='T'))
 
-from mock_data import ExampleDirSpiders
 class ExampleDirLinks(ExampleDirSpiders):
     """Extended example dir for testing symbolic link handling
 

--- a/bcftbx/utils.py
+++ b/bcftbx/utils.py
@@ -213,7 +213,7 @@ def getlines(filen):
     Fetch lines from a file and return them one by one
 
     This generator function tries to implement an efficient
-    method of reading lines sequentially from a file, by
+    method of reading lines sequentially from a text file, by
     minimising the number of reads from the file and
     performing the line splitting in memory. It attempts
     to replicate the idiom:
@@ -238,9 +238,9 @@ def getlines(filen):
         newline character removed.
     """
     if filen.split('.')[-1] == 'gz':
-        fp = gzip.open(filen,'rb')
+        fp = gzip.open(filen,'rt')
     else:
-        fp = io.open(filen,'rb')
+        fp = io.open(filen,'rt')
     # Read in data in chunks
     buf = ''
     lines = []

--- a/bcftbx/utils.py
+++ b/bcftbx/utils.py
@@ -91,6 +91,7 @@ import grp
 import datetime
 import re
 import socket
+from builtins import range
 
 #######################################################################
 # Module constants
@@ -1468,7 +1469,7 @@ def parse_lanes(lane_expr):
             i = field.index('-')
             l1 = int(field[:i])
             l2 = int(field[i+1:])
-            for i in xrange(l1,l2+1): lanes.append(i)
+            for i in range(l1,l2+1): lanes.append(i)
         except ValueError:
             # Not a range
             lanes.append(int(field))

--- a/bcftbx/utils.py
+++ b/bcftbx/utils.py
@@ -1384,7 +1384,7 @@ def split_into_lines(text,char_limit,delimiters=' \t\n',
             for delim in delimiters:
                 try:
                     j = text[:char_limit].rindex(delim)
-                    i = max(i,j)
+                    i = max([x for x in [i,j] if x is not None])
                 except ValueError:
                     pass
         if i is None:


### PR DESCRIPTION
PR which updates the `bcftbx/utils` module to fix compatibility issues between Python 2 and 3, including:

* Fixing relative imports in unit tests
* Removing `xrange` in favour of forwards-compatible `range` function
* Reimplementing use of `max` built-in function to handle `None` values
* Updating `getlines` to explicitly read data as text
* Fixing unit tests for `concatenate_fastq_files` when handling gzipped Fastqs