### PR TITLE
bcftbx/SolidData: fixes for Python2/3 compatibility issues

### DIFF
--- a/bcftbx/SolidData.py
+++ b/bcftbx/SolidData.py
@@ -659,7 +659,8 @@ class SolidLibrary(object):
         # Append to the list of primary data files
         self.primary_data.append(primary_data)
         # Sort into timestamp order (newest to older)
-        self.primary_data.sort(lambda a,b: cmp(b.timestamp,a.timestamp))
+        self.primary_data = sorted(self.primary_data,
+                                   key=lambda x: x.timestamp)
         # Return the SolidPrimaryData object
         return primary_data
 

--- a/bcftbx/SolidData.py
+++ b/bcftbx/SolidData.py
@@ -436,7 +436,13 @@ class SolidRun(object):
         return slide_layout(len(self.samples))
 
     def __nonzero__(self):
-        """Implement nonzero built-in
+        """Implement __nonzero__ built-in
+
+        """
+        return self.__bool__()
+
+    def __bool__(self):
+        """Implement __bool__ built-in
 
         SolidRun object is False if the source directory doesn't
         exist, or if basic data couldn't be loaded."""
@@ -1000,7 +1006,11 @@ class SolidRunDefinition(object):
 
     def __nonzero__(self):
         """Implement the built-in __nonzero__ method"""
-        return len(self.data) != 0
+        return self.__bool__()
+
+    def __bool__(self):
+        """Implement the built-in __bool__ method"""
+        return (len(self.data) != 0)
 
     def fields(self):
         """Return list of fields"""
@@ -1085,8 +1095,13 @@ class SolidBarcodeStatistics(object):
             logging.error("Failed to populate SolidBarcodeStatistics: '%s'" % ex)
 
     def __nonzero__(self):
-        """Implement the __nonzero__ built-in"""
-        return len(self.data) != 0
+        """Implement __nonzero__ built-in
+        """
+        return self.__bool__()
+
+    def __bool__(self):
+        """Implement the __bool__ built-in"""
+        return (len(self.data) != 0)
 
     def populate(self):
         """Populate the SolidBarcodeStatistics object.

--- a/bcftbx/SolidData.py
+++ b/bcftbx/SolidData.py
@@ -60,7 +60,7 @@ import os
 import io
 import string
 import logging
-import utils
+from . import utils
 
 #######################################################################
 # Class definitions


### PR DESCRIPTION
PR which updates the `bcftbx/SolidData` module to fix issues with Python 2/3 compatibility:

* Fix relative import of the `utils` module
* Switch to using `sorted(...,key=...)` function, instead of built-in list sorting method with `cmp`
* Implement `__bool__` methods for classes where `__nonzero__` was already implemented