### PR TITLE
bcftbx/Spreadsheet: fix 'Worksheet.column_id_from_index' for Python 2/3 compatibility

### DIFF
--- a/bcftbx/Spreadsheet.py
+++ b/bcftbx/Spreadsheet.py
@@ -78,8 +78,13 @@ __version__ = "0.1.11"
 
 import os
 import re
-import string
 import logging
+try:
+    # Python 3
+    from string import ascii_uppercase
+except ImportError:
+    # Fallback for Python 2
+    from string import uppercase as ascii_uppercase
 
 import xlwt, xlrd
 import xlutils, xlutils.copy
@@ -507,8 +512,8 @@ class Worksheet(object):
         name = ''
         try:
             while i >= 0:
-                name += string.uppercase[i%26]
-                i = i/26-1
+                name += ascii_uppercase[i%26]
+                i = i//26-1
             return name[::-1]
         except IndexError as ex:
             print("Exception getting column name for index %d: %s" % (i,ex))


### PR DESCRIPTION
PR which updates the `bcftbx/Spreadsheet` module to use either 'uppercase' (Python2) or 'ascii_uppercase' (Python3) as appropriate, and explicitly specify integer division operator in the `Worksheet.column_id_from_index()` method.