### PR TITLE
bcftbx/simple_xls: fixes for Python2/3 compatibility

### DIFF
--- a/bcftbx/simple_xls.py
+++ b/bcftbx/simple_xls.py
@@ -407,7 +407,7 @@ class XLSWorkSheet(object):
         self.data[idx.idx] = value
         if idx.column not in self.columns:
             self.columns.append(idx.column)
-        self.columns.sort(cmp=cmp_column_indices)
+        self.columns = sorted(self.columns,key=lambda x: x[::-1])
         if idx.row not in self.rows:
             self.rows.append(idx.row)
         self.rows.sort()
@@ -660,7 +660,7 @@ class XLSWorkSheet(object):
                 self.set_style(style,cell(col,row))
             row += 1
         # Sort the column and row indices
-        self.columns.sort(cmp=cmp_column_indices)
+        self.columns = sorted(self.columns,key=lambda x: x[::-1])
         self.rows.sort()
 
     def insert_column_data(self,col,data,start=None,style=None):
@@ -846,7 +846,7 @@ class XLSWorkSheet(object):
                 self.set_style(style,cell(col,row))
             col = incr_col(col)
         # Sort the column and row indices
-        self.columns.sort(cmp=cmp_column_indices)
+        self.columns = sorted(self.columns,key=lambda x: x[::-1])
         self.rows.sort()
 
     def insert_row_data(self,row,data,start=None,style=None):

--- a/bcftbx/simple_xls.py
+++ b/bcftbx/simple_xls.py
@@ -1499,7 +1499,7 @@ def column_integer_to_index(idx):
     col = ''
     while idx >= 0:
         col += chr((idx%26)+65)
-        idx = idx/26-1
+        idx = idx//26-1
     return col[::-1]
 
 def eval_formula(item,worksheet):
@@ -1626,7 +1626,7 @@ def format_value(value,number_format=None):
         value = []
         while i >= 1000:
             value.append("%03d" % (i%1000))
-            i = i/1000
+            i = i//1000
         value.append(str(i))
         value = value[::-1]
         return ','.join(value)

--- a/bcftbx/simple_xls.py
+++ b/bcftbx/simple_xls.py
@@ -122,6 +122,7 @@ import logging
 import xlsxwriter
 from . import Spreadsheet
 from .utils import OrderedDictionary
+from builtins import range
 
 #######################################################################
 # Constants
@@ -261,7 +262,7 @@ class XLSWorkBook(object):
             for col in ColumnRange(start.column,end.column):
                 # Maximum column width
                 max_width = default_min_col_width
-                for row in xrange(start.row,end.row+1):
+                for row in range(start.row,end.row+1):
                     # Get the value
                     value = worksheet.render_cell(cell(col,row),
                                                   eval_formulae=False,
@@ -955,7 +956,7 @@ class XLSWorkSheet(object):
             j = self.last_row
         else:
             j = int(end)
-        for row in xrange(i,j+1):
+        for row in range(i,j+1):
             self[cell(column,row)] = item
             if style is not None:
                 self.set_style(style,cell(column,row))
@@ -986,7 +987,7 @@ class XLSWorkSheet(object):
         start_cell = CellIndex(start)
         end_cell = CellIndex(end)
         for col in ColumnRange(start_cell.column,end_cell.column):
-            for row in xrange(start_cell.row,end_cell.row+1):
+            for row in range(start_cell.row,end_cell.row+1):
                 self.styles[cell(col,row)] = cell_style
 
     def get_style(self,idx):
@@ -1109,7 +1110,7 @@ class XLSWorkSheet(object):
             for col in ColumnRange(start.column,end.column):
                 line.append(col)
             text.append('\t'.join(line))
-        for row in xrange(start.row,end.row+1):
+        for row in range(start.row,end.row+1):
             line = []
             if include_columns_and_rows:
                 line.append(u'%s' % row)
@@ -1689,7 +1690,7 @@ if __name__ == "__main__":
                   style=XLSStyle(color='white',
                                  bgcolor='green',
                                  bold=True))
-    for i in xrange(100):
+    for i in range(100):
         ws.append_row(data=(i,i*2,'=A?+B?'))
     ws.freeze_panes = 'A2'
     # Save out to XLS(X) files

--- a/bcftbx/simple_xls.py
+++ b/bcftbx/simple_xls.py
@@ -1171,6 +1171,9 @@ class XLSStyle(object):
         self.shrink_to_fit = shrink_to_fit
 
     def __nonzero__(self):
+        return self.__bool__()
+
+    def __bool__(self):
         return \
             (self.bold) or \
             (self.color is not None) or \

--- a/bcftbx/simple_xls.py
+++ b/bcftbx/simple_xls.py
@@ -1438,7 +1438,7 @@ def cmp_column_indices(x,y):
 
     """
     # Do string comparision on reverse of column indices
-    return cmp(x[::-1],y[::-1])
+    return (x[::-1] > y[::-1]) - (x[::-1] < y[::-1])
 
 def cell(col,row):
     """Return XLS cell index for column and row

--- a/bcftbx/simple_xls.py
+++ b/bcftbx/simple_xls.py
@@ -1317,7 +1317,13 @@ class ColumnRange(Iterator):
             self.end += self.incr
 
     def next(self):
-        """Implements Iterator subclass 'next' method
+        """Implements Iterator subclass 'next' method (Python 2 only)
+
+        """
+        return self.__next__()
+
+    def __next__(self):
+        """Implements Iterator subclass '__next__' method
 
         """
         self.column = self.column + self.incr

--- a/bcftbx/test/test_simple_xls.py
+++ b/bcftbx/test/test_simple_xls.py
@@ -3,9 +3,14 @@
 #######################################################################
 from bcftbx.simple_xls import *
 import unittest
-import itertools
 import os
 import tempfile
+try:
+    # Python 2
+    from itertools import izip as zip
+except ImportError:
+    pass
+from builtins import range
 
 class TestXLSWorkBook(unittest.TestCase):
     """
@@ -204,13 +209,13 @@ class TestXLSWorkSheet(unittest.TestCase):
         ws.write_column('B',data=col_data)
         self.assertEqual(ws.last_column,'B')
         self.assertEqual(ws.last_row,3)
-        for i in xrange(3):
+        for i in range(3):
             self.assertEqual(ws[exp_cell[i]],col_data[i])
         exp_cell = ['C3','C4','C5']
         ws.write_column('C',data=col_data,from_row=3)
         self.assertEqual(ws.last_column,'C')
         self.assertEqual(ws.last_row,5)
-        for i in xrange(3):
+        for i in range(3):
             self.assertEqual(ws[exp_cell[i]],col_data[i])
     def test_write_column_with_text(self):
         ws = self.ws
@@ -219,14 +224,14 @@ class TestXLSWorkSheet(unittest.TestCase):
         ws.write_column('A',text="hello\ngoodbye\nwhatev")
         self.assertEqual(ws.last_column,'A')
         self.assertEqual(ws.last_row,3)
-        for i in xrange(3):
+        for i in range(3):
             self.assertEqual(ws[exp_cell[i]],col_data[i])
         exp_cell = ['M7','M8','M9']
         ws.write_column('M',text="hello\ngoodbye\nwhatev",
                         from_row=7)
         self.assertEqual(ws.last_column,'M')
         self.assertEqual(ws.last_row,9)
-        for i in xrange(3):
+        for i in range(3):
             self.assertEqual(ws[exp_cell[i]],col_data[i])
     def test_write_column_with_fill(self):
         ws = self.ws
@@ -248,11 +253,11 @@ class TestXLSWorkSheet(unittest.TestCase):
         col_data = ['hello','goodbye','whatev']
         exp_cell = ['B1','B2','B3']
         ws.insert_column_data('B',col_data)
-        for i in xrange(3):
+        for i in range(3):
             self.assertEqual(ws[exp_cell[i]],col_data[i])
         exp_cell = ['C3','C4','C5']
         ws.insert_column_data('C',col_data,start=3)
-        for i in xrange(3):
+        for i in range(3):
             self.assertEqual(ws[exp_cell[i]],col_data[i])
     def test_insert_row(self):
         ws = self.ws
@@ -302,13 +307,13 @@ class TestXLSWorkSheet(unittest.TestCase):
         ws.write_row(4,data=row_data)
         self.assertEqual(ws.last_column,'D')
         self.assertEqual(ws.last_row,4)
-        for i in xrange(4):
+        for i in range(4):
             self.assertEqual(ws[exp_cell[i]],row_data[i])
         exp_cell = ['E5','F5','G5','H5']
         ws.write_row(5,data=row_data,from_column='E')
         self.assertEqual(ws.last_column,'H')
         self.assertEqual(ws.last_row,5)
-        for i in xrange(4):
+        for i in range(4):
             self.assertEqual(ws[exp_cell[i]],row_data[i])
     def test_write_row_with_text(self):
         ws = self.ws
@@ -318,24 +323,24 @@ class TestXLSWorkSheet(unittest.TestCase):
         ws.write_row(4,text=row_text)
         self.assertEqual(ws.last_column,'D')
         self.assertEqual(ws.last_row,4)
-        for i in xrange(4):
+        for i in range(4):
             self.assertEqual(ws[exp_cell[i]],row_data[i])
         exp_cell = ['E5','F5','G5','H5']
         ws.write_row(5,text=row_text,from_column='E')
         self.assertEqual(ws.last_column,'H')
         self.assertEqual(ws.last_row,5)
-        for i in xrange(4):
+        for i in range(4):
             self.assertEqual(ws[exp_cell[i]],row_data[i])
     def test_insert_row_data(self):
         ws = self.ws
         row_data = ['Dozy','Beaky','Mick','Titch']
         exp_cell = ['A4','B4','C4','D4']
         ws.insert_row_data(4,row_data)
-        for i in xrange(4):
+        for i in range(4):
             self.assertEqual(ws[exp_cell[i]],row_data[i])
         exp_cell = ['E5','F5','G5','H5']
         ws.insert_row_data(5,row_data,start='E')
-        for i in xrange(4):
+        for i in range(4):
             self.assertEqual(ws[exp_cell[i]],row_data[i])
     def test_insert_block_data(self):
         ws = self.ws
@@ -475,22 +480,20 @@ class TestColumnRange(unittest.TestCase):
     """
     """
     def test_column_range(self):
-        for expected,actual in itertools.izip(['A','B','C'],
-                                              ColumnRange('A','C')):
+        for expected,actual in zip(['A','B','C'],
+                                   ColumnRange('A','C')):
             self.assertEqual(expected,actual)
     def test_column_range_implicit_start(self):
-        for expected,actual in itertools.izip(['A','B','C'],
-                                              ColumnRange('C')):
+        for expected,actual in zip(['A','B','C'],
+                                   ColumnRange('C')):
             self.assertEqual(expected,actual)
     def test_column_range_dont_include_end(self):
-        for expected,actual in itertools.izip(['A','B','C'],
-                                              ColumnRange('A','D',
-                                                          include_end=False)):
+        for expected,actual in zip(['A','B','C'],
+                                   ColumnRange('A','D',include_end=False)):
             self.assertEqual(expected,actual)
     def test_column_range_reverse(self):
-        for expected,actual in itertools.izip(['C','B','A'],
-                                              ColumnRange('A','C',
-                                                          reverse=True)):
+        for expected,actual in zip(['C','B','A'],
+                                   ColumnRange('A','C',reverse=True)):
             self.assertEqual(expected,actual)
 
 class TestXLSStyle(unittest.TestCase):


### PR DESCRIPTION
PR which implements a number of updates to the `bcftbx/simple_xls` module for Python 2/3 compatibility:

* Switch column sorting to use `sorted(...,key=...`)
* Reimplement the column indices comparison function to drop the `cmp` builtin (which is unavailable in Python3)
* Switch from `xrange` to Python3-compatible version of `range`
* Implement the `__bool__` method on the `XLSStyle` class in parallel with the existing `__nonzero__` method
* Implement the `__next__` method on the `ColumnRange` iterator class in parallel with the existing `next` method
* Fix the integer division operator (i.e. use `//` rather than `/`)