### PR TITLE
bcftbx/cmdparse: handle --version on arbitrary subparsers

### DIFF
--- a/bcftbx/cmdparse.py
+++ b/bcftbx/cmdparse.py
@@ -137,7 +137,16 @@ class CommandParser(object):
                                       cmd)
         if 'version' not in args:
             args['version'] = self._version
-        p = self._subparser(**args)
+        try:
+            # Try to create parse including version
+            p = self._subparser(**args)
+        except TypeError:
+            # Try again without the version argument
+            version = args['version']
+            del(args['version'])
+            p = self._subparser(**args)
+            # Add the --version argument manually
+            add_arg(p,'--version',action='version',version=version)
         self._commands[cmd] = p
         self._help[cmd] = help
         return p

--- a/bcftbx/test/test_cmdparse.py
+++ b/bcftbx/test/test_cmdparse.py
@@ -87,6 +87,15 @@ class TestCommandParserOptionParser(unittest.TestCase):
             self.fail("Accessing 'a_value' for 'fast' command didn't raise AttributeError")
         except AttributeError:
             pass
+    def test_handles_version(self):
+        """CommandParser handles version using optparse
+        """
+        # Skip the test if optparse not available
+        if not OPTPARSE_AVAILABLE:
+            raise unittest.SkipTest("'optparse' not available")
+        p = CommandParser(subparser=OptionParser,version="0.1")
+        slow_cmd = p.add_command('slow')
+        fast_cmd = p.add_command('fast')
 
 class TestCommandParserWithArgumentParser(unittest.TestCase):
     """Tests for CommandParser using explicit ArgumentParser backend
@@ -147,6 +156,12 @@ class TestCommandParserWithArgumentParser(unittest.TestCase):
             self.fail("Accessing 'a_value' for 'fast' command didn't raise AttributeError")
         except AttributeError:
             pass
+    def test_handles_version(self):
+        """CommandParser handles version using argparse
+        """
+        p = CommandParser(subparser=ArgumentParser,version="0.1")
+        slow_cmd = p.add_command('slow')
+        fast_cmd = p.add_command('fast')
 
 class TestAddOptionFunctions(unittest.TestCase):
     """Tests for the various 'add_..._option' functions


### PR DESCRIPTION
PR which fixes a problem in the `bcftbx/cmdparse` module when setting the version on subparsers for some versions of Python (specifically, in some versions the `argparse.ArgumentParser` class doesn't support a `version` parameter on instantiation).

The fix works around this by attempting to explicitly add the `--version` argument if it appears it is not implicitly supported at instantiation.