### PR TITLE
Fix broken --version options on 'make_macs_xls.py' & 'make_macs2_xls.py'

### DIFF
--- a/ChIP-seq/make_macs2_xls.py
+++ b/ChIP-seq/make_macs2_xls.py
@@ -51,7 +51,7 @@ import profile
 # Module metadata
 #######################################################################
 
-__version__ = '0.6.2'
+__version__ = '0.6.3'
 
 #######################################################################
 # Class definitions
@@ -1144,14 +1144,15 @@ def main(macs_file,xls_out,xls_format="xlsx",bed_out=None):
 
 if __name__ == "__main__":
     # Process command line
-    p = argparse.ArgumentParser(version="%(prog)s "+__version__,
-                                description=
+    p = argparse.ArgumentParser(description=
                                 "Create an XLS(X) spreadsheet from the output "
                                 "of the MACS2 peak caller. MACS2_XLS is the "
                                 "output '.xls' file from MACS2; if supplied "
                                 "then XLS_OUT is the name to use for the output "
                                 "file (otherwise it will be called "
                                 "'XLS_<MACS2_XLS>.xls(x)').")
+    p.add_argument('--version',action='version',
+                   version="%(prog)s "+__version__)
     p.add_argument("-f","--format",
                    action="store",dest="xls_format",default="xlsx",
                    help="specify the output Excel spreadsheet format; must be "

--- a/ChIP-seq/make_macs_xls.py
+++ b/ChIP-seq/make_macs_xls.py
@@ -45,7 +45,7 @@ import bcftbx.Spreadsheet as Spreadsheet
 # Module metadata
 #######################################################################
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 
 #######################################################################
 # Class definitions
@@ -66,12 +66,13 @@ __version__ = '0.2.1'
 if __name__ == "__main__":
     # Process command line
     p = argparse.ArgumentParser(
-        version="%(prog)s "+__version__,
         description=
         "Create an XLS spreadsheet from the output of the MACS peak "
         "caller. <MACS_OUTPUT> is the output '.xls' file from MACS; "
         "if supplied then <XLS_OUT> is the name to use for the output "
         "file, otherwise it will be called 'XLS_<MACS_OUTPUT>.xls'.")
+    p.add_argument('--version',action='version',
+                   version="%(prog)s "+__version__)
     p.add_argument('macs_in',metavar="MACS_OUTPUT",action='store',
                    help="output .xls file from MACS")
     p.add_argument('xls_out',metavar="XLS_OUT",action='store',nargs='?',


### PR DESCRIPTION
PR which fixes the `--version` command line options for the `ChIP-seq` utilities `make_macs_xls.py` and `make_macs2_xls.py`, which were broken under Python 3.