### PR TITLE
Illumina2cluster: update utilities for Python3 compatibility

### DIFF
--- a/illumina2cluster/prep_sample_sheet.py
+++ b/illumina2cluster/prep_sample_sheet.py
@@ -15,7 +15,7 @@ Prepare sample sheet file for Illumina sequencers.
 
 """
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 #######################################################################
 # Imports
@@ -91,11 +91,12 @@ if __name__ == "__main__":
 
     # Set up parser
     p = argparse.ArgumentParser(
-        version="%(prog)s "+__version__,
         description="Utility to prepare SampleSheet files from "
         "Illumina sequencers. Can be used to view, validate and "
         "update or fix information such as sample IDs and project "
         "names before running BCL to FASTQ conversion.")
+    p.add_argument('--version',action='version',
+                   version="%(prog)s "+__version__)
     p.add_argument('-o',action="store",dest="samplesheet_out",
                    default=None,
                    help="output new sample sheet to SAMPLESHEET_OUT")

--- a/illumina2cluster/report_barcodes.py
+++ b/illumina2cluster/report_barcodes.py
@@ -66,8 +66,7 @@ class Barcodes(object):
         into alphabetical order.
 
         """
-        unique = self._counts.keys()
-        unique.sort()
+        unique = sorted(list(self._counts.keys()))
         return unique
 
     def count_for(self,*seqs):


### PR DESCRIPTION
PR which updates utilities in the `illumina2cluster` directory for Python 2/3 compatibility:

* `prep_sample_sheet.py`: fixes `--version` option which was broken for Python 3, and
* `report_barcodes.py`: update sorting of dictionary keys, which was also broken for Python 3.