### PR TITLE
NGS-general: update utilities for Python2/3 compatibility

### DIFF
--- a/NGS-general/manage_seqs.py
+++ b/NGS-general/manage_seqs.py
@@ -546,13 +546,14 @@ if __name__ == '__main__':
 
     # Command line processing
     p = argparse.ArgumentParser(
-        version="%(prog)s "+__version__,
         description="Read sequences and names from one or more "
         "INFILEs (which can be a mixture of FastQC 'contaminants' "
         "format and or Fasta format), check for redundancy "
         "(i.e. sequences with multiple associated names) and "
         "contradictions (i.e. names with multiple associated "
         "sequences).")
+    p.add_argument('--version',action='version',
+                   version="%(prog)s "+__version__)
     p.add_argument('-o',action='store',dest='out_file',default=None,
                    help="write all sequences to OUT_FILE in FastQC "
                    "'contaminants' format")

--- a/NGS-general/manage_seqs.py
+++ b/NGS-general/manage_seqs.py
@@ -25,7 +25,7 @@ manage_seqs.py [-o OUTFILE|-a OUTFILE] [-d DESCRIPTION] INFILE [INFILE...]
 # Module metadata
 #######################################################################
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 #######################################################################
 # Import modules that this module depends on

--- a/NGS-general/manage_seqs.py
+++ b/NGS-general/manage_seqs.py
@@ -108,7 +108,7 @@ class SeqDb(object):
         
         """
         if name is None:
-            seqs = copy.copy(self._sequences.keys())
+            seqs = copy.copy(list(self._sequences.keys()))
         else:
             seqs = []
             for seq in self._sequences:

--- a/NGS-general/reorder_fasta.py
+++ b/NGS-general/reorder_fasta.py
@@ -31,6 +31,7 @@ import argparse
 import itertools
 import tempfile
 import logging
+from future.moves.itertools import zip_longest
 
 #######################################################################
 # Module metadata
@@ -88,11 +89,14 @@ def cmp_chrom_names(x,y):
       Integer: negative if x < y, zero if x == y, positive if
         x > y.
     """
-    for i,j in itertools.izip_longest(split_chrom_name(x),
-                                      split_chrom_name(y)):
-        c = cmp(i,j)
-        if c != 0:
-            return c
+    for i,j in zip_longest(split_chrom_name(x),
+                           split_chrom_name(y)):
+        if i != j:
+            if i is None:
+                return -1
+            elif j is None:
+                return 1
+            return ((i > j) - (i < j))
     return 0
 
 #######################################################################

--- a/NGS-general/sam2soap.py
+++ b/NGS-general/sam2soap.py
@@ -28,6 +28,7 @@ import os
 import io
 import logging
 import argparse
+from builtins import range
 
 #######################################################################
 # Class definitions
@@ -262,7 +263,7 @@ def recover_reference_sequence(aligned_seq,cigar_string,md_tag):
         if code == 'M':
             # (Mis)match
             # Keep aligned sequence for now
-            for i in xrange(count):
+            for i in range(count):
                 refseq.append(aligned_seq[index])
                 index += 1
         elif code == 'I':
@@ -272,7 +273,7 @@ def recover_reference_sequence(aligned_seq,cigar_string,md_tag):
         elif code == 'D':
             # Deletion
             # Add placeholders for unknown bases
-            for i in xrange(count):
+            for i in range(count):
                 refseq.append('x')
         else:
             logging.error('Unknown operation: %s' % op)

--- a/NGS-general/split_fasta.py
+++ b/NGS-general/split_fasta.py
@@ -79,6 +79,12 @@ class FastaChromIterator(Iterator):
         self.__line = None
 
     def next(self):
+        """Return next chromosome from Fasta file as a (name,sequence) tuple (Python 2)
+
+        """
+        return self.__next__()
+
+    def __next__(self):
         """Return next chromosome from Fasta file as a (name,sequence) tuple
        
         """

--- a/NGS-general/split_fasta.py
+++ b/NGS-general/split_fasta.py
@@ -184,10 +184,11 @@ def run_tests():
 if __name__ == "__main__":
     # Process the command line
     p = argparse.ArgumentParser(
-        version="%(prog)s "+__version__,
         description="Split input FASTA file with multiple sequences "
         "into multiple files each containing sequences for a single "
         "chromosome.")
+    p.add_argument('--version',action='version',
+                   version="%(prog)s "+__version__)
     p.add_argument("--test",action="store_true",dest="run_tests",
                    default=False,
                    help="Run unit tests")

--- a/NGS-general/split_fasta.py
+++ b/NGS-general/split_fasta.py
@@ -22,7 +22,7 @@ data chromosome-by-chromosome from a Fasta file.
 # Module metadata
 #######################################################################
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 #######################################################################
 # Import modules

--- a/NGS-general/split_fastq.py
+++ b/NGS-general/split_fastq.py
@@ -68,7 +68,7 @@ AAF#FJJJJJJJJJJJ
     def test_get_fastq_lanes_from_gzipped_input(self):
         # Make test gzipped Fastq
         fastq_in = os.path.join(self.wd,"Test_S1_R1_001.fastq.gz")
-        with gzip.open(fastq_in,'w') as fp:
+        with gzip.open(fastq_in,'wt') as fp:
             fp.write(self.fastq_data)
         # Extract lanes
         nreads,lanes = get_fastq_lanes(fastq_in)
@@ -126,7 +126,7 @@ AAF#FJJJJJJJJJJJ
     def test_get_fastq_lanes_from_gzipped_input(self):
         # Make test gzipped Fastq
         fastq_in = os.path.join(self.wd,"Test_S1_R1_001.fastq.gz")
-        with gzip.open(fastq_in,'w') as fp:
+        with gzip.open(fastq_in,'wt') as fp:
             fp.write(self.fastq_data_l2)
             fp.write(self.fastq_data_l8)
         # Extract reads for lane 2


### PR DESCRIPTION
PR which updates the utilities in `NGS-general` for Python 2/3 compatibility:

* `manage_seqs.py`: fix `--version` command line option which was broken under Python 3, and explicitly cast dictionary keys to a list for Python 3
* `reorder_fasta.py`: switch from `izip_longest` in unit tests to a Python 2/3 compatible version of `zip_longest`
* `sam2soap.py`: switch from Python2-only `xrange` to Python2/3 compatible version of `range`
* `split_fasta.py`:  fix `--version` command line option which was broken under Python 3, and add `__next__` method to `FastaChromIterator` for Python 3
* `split_fastq.py`: fix the mode used to write gzipped test files in the unit tests