### PR TITLE
Fixes to Python utilities and library modules to use 'collections.abc'

### DIFF
--- a/NGS-general/split_fasta.py
+++ b/NGS-general/split_fasta.py
@@ -22,13 +22,16 @@ data chromosome-by-chromosome from a Fasta file.
 # Module metadata
 #######################################################################
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 
 #######################################################################
 # Import modules
 #######################################################################
 
-from collections import Iterator
+try:
+    from collections.abc import Iterator
+except ImportError:
+    from collections import Iterator
 import sys
 import os
 import io

--- a/bcftbx/FASTQFile.py
+++ b/bcftbx/FASTQFile.py
@@ -26,7 +26,7 @@ Information on the FASTQ file format: http://en.wikipedia.org/wiki/FASTQ_format
 
 """
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"
 
 CHUNKSIZE = 102400
 
@@ -34,7 +34,10 @@ CHUNKSIZE = 102400
 # Import modules that this module depends on
 #######################################################################
 from builtins import str
-from collections import Iterator
+try:
+    from collections.abc import Iterator
+except ImportError:
+    from collections import Iterator
 import os
 import io
 import re

--- a/bcftbx/simple_xls.py
+++ b/bcftbx/simple_xls.py
@@ -109,7 +109,7 @@ Alternatively the contents of a sheet (or a subset) can be rendered as text:
 
 """
 
-__version__ = "0.0.12"
+__version__ = "0.0.13"
 
 #######################################################################
 # Import modules that this module depends on
@@ -117,7 +117,10 @@ __version__ = "0.0.12"
 
 from builtins import str
 import re
-from collections import Iterator
+try:
+    from collections.abc import Iterator
+except ImportError:
+    from collections import Iterator
 import logging
 import xlsxwriter
 from . import Spreadsheet

--- a/microarray/best_exons.py
+++ b/microarray/best_exons.py
@@ -5,7 +5,7 @@
 #
 ########################################################################
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"
 
 """
 best_exons.py
@@ -63,7 +63,10 @@ import os
 import io
 import argparse
 import logging
-from collections import Iterator
+try:
+    from collections.abc import Iterator
+except ImportError:
+    from collections import Iterator
 from operator import attrgetter
 
 # Put .. onto Python search path for modules


### PR DESCRIPTION
PR which updates the following Python utilities and library modules to switch from `collections` to `collections.abc` (with fallback to `collections` if `collections.abc` is not available):

* `NGS-general/split_fasta.py`
* `bcftbx/FASTQFile.py`
* `bcftbx/simple_xls.py`
* `microarray/best_exons.py`

This is to deal with the following change:

> Changed in version 3.3: Moved Collections Abstract Base Classes to the collections.abc module. > For backwards compatibility, they continue to be visible in this module through Python 3.7. Subsequently, they will be removed entirely.