### PR TITLE
Handle cases when Value is missing from Key,Value

### DIFF
--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -1099,7 +1099,10 @@ class SampleSheet(object):
         """
         fields = line.split(',')
         param = fields[0]
-        value = fields[1]
+        if len(fields) > 1:
+            value = fields[1]
+        else:
+            value = ''
         # Handle quoted value containing commas
         if value.startswith('"'):
             for f in fields[2:]:


### PR DESCRIPTION
My Header section looks like this:
[Header]
IEMFileVersion,4
Date,11/16/2015
Workflow,GenerateFASTQ
Application,RNA-Seq
Assay,TruSeq LT
Description
Chemistry,Default

Hence the Value in Description is None.  The fix catches cases like this.