### PR TITLE
bcftbx/IlluminaData: fix error in call to 'digits' method in 'split_run_name_full'

### DIFF
--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -2520,7 +2520,7 @@ def split_run_name_full(dirname):
     component is used as the ID.
     """
     fields = os.path.basename(dirname).split('_')
-    if len(fields) > 3 and fields[0].isdigit and \
+    if len(fields) > 3 and fields[0].isdigit() and \
        (len(fields[0]) == 6 or len(fields[0]) == 8):
         date_stamp = fields[0]
     else:

--- a/bcftbx/test/test_IlluminaData.py
+++ b/bcftbx/test/test_IlluminaData.py
@@ -3608,6 +3608,9 @@ class TestSplitRunNameFull(unittest.TestCase):
                           'this_is_nonsense')
         self.assertRaises(IlluminaDataError,
                           split_run_name_full,
+                          'sixchr_10Xrun_BCLFiles_Download')
+        self.assertRaises(IlluminaDataError,
+                          split_run_name_full,
                           '140210')
         self.assertRaises(IlluminaDataError,
                           split_run_name_full,


### PR DESCRIPTION
PR which fixes a bug in `split_run_name_full` (in the `bcftbx.IlluminaData` module) - the check on putative datestamps should include a call to the `digits` method but in fact just checked whether the method existed. As a result it was possible for invalid 6- and 8-character strings to pass as datestamps.

The fix now means that strings which are not composed of digits will always fail the test for whether they are valid datestamps.