### PR TITLE
bcftbx/FASTQFile: fixes for Python2/3 compatibility when reading files from disk

### DIFF
--- a/bcftbx/FASTQFile.py
+++ b/bcftbx/FASTQFile.py
@@ -443,7 +443,7 @@ class FastqAttributes(object):
 # Functions
 #######################################################################
 
-def get_fastq_file_handle(fastq):
+def get_fastq_file_handle(fastq,mode='rb'):
     """Return a file handle opened for reading for a FASTQ file
 
     Deals with both compressed (gzipped) and uncompressed FASTQ
@@ -452,15 +452,16 @@ def get_fastq_file_handle(fastq):
     Arguments:
       fastq: name (including path, if required) of FASTQ file.
         The file can be gzipped (must have '.gz' extension)
+      mode: optional mode for file opening (defaults to 'rb')
 
     Returns:
       File handle that can be used for read operations.
 
     """
     if os.path.splitext(fastq)[1] == '.gz':
-        return gzip.open(fastq,'rb')
+        return gzip.open(fastq,mode)
     else:
-        return io.open(fastq,'rb')
+        return io.open(fastq,mode)
 
 def nreads(fastq=None,fp=None):
     """Return number of reads in a FASTQ file

--- a/bcftbx/FASTQFile.py
+++ b/bcftbx/FASTQFile.py
@@ -1,5 +1,5 @@
 #     FASTQFile.py: read and manipulate FASTQ files and data
-#     Copyright (C) University of Manchester 2012-19 Peter Briggs
+#     Copyright (C) University of Manchester 2012-2020 Peter Briggs
 #
 ########################################################################
 #
@@ -25,8 +25,6 @@ Additionally there are a few utility functions:
 Information on the FASTQ file format: http://en.wikipedia.org/wiki/FASTQ_format
 
 """
-
-__version__ = "1.0.5"
 
 CHUNKSIZE = 102400
 

--- a/bcftbx/FASTQFile.py
+++ b/bcftbx/FASTQFile.py
@@ -33,7 +33,7 @@ CHUNKSIZE = 102400
 #######################################################################
 # Import modules that this module depends on
 #######################################################################
-from builtins import str
+
 try:
     from collections.abc import Iterator
 except ImportError:
@@ -99,7 +99,7 @@ class FastqIterator(Iterator):
         self.__fastq_file = fastq_file
         self.__bufsize = bufsize
         if fp is None:
-            self.__fp = get_fastq_file_handle(self.__fastq_file,'rb')
+            self.__fp = get_fastq_file_handle(self.__fastq_file,'rt')
         else:
             self.__fp = fp
         self._buf = ''
@@ -117,14 +117,14 @@ class FastqIterator(Iterator):
         # Do we already have a read to return?
         while len(lines) < 4:
             # Fetch more data
-            data = self.__fp.read(bufsize).decode()
+            data = self.__fp.read(bufsize)
             if not data:
                 # Reached EOF
                 if self.__fastq_file is None:
                     self.__fp.close()
                 raise StopIteration
             # Add to buffer and split into lines
-            buf = buf + data
+            buf = buf + str(data)
             if buf[-1] != '\n':
                 i = buf.rfind('\n')
                 if i == -1:

--- a/bcftbx/FASTQFile.py
+++ b/bcftbx/FASTQFile.py
@@ -443,7 +443,7 @@ class FastqAttributes(object):
 # Functions
 #######################################################################
 
-def get_fastq_file_handle(fastq,mode='rb'):
+def get_fastq_file_handle(fastq,mode='rt'):
     """Return a file handle opened for reading for a FASTQ file
 
     Deals with both compressed (gzipped) and uncompressed FASTQ
@@ -452,7 +452,7 @@ def get_fastq_file_handle(fastq,mode='rb'):
     Arguments:
       fastq: name (including path, if required) of FASTQ file.
         The file can be gzipped (must have '.gz' extension)
-      mode: optional mode for file opening (defaults to 'rb')
+      mode: optional mode for file opening (defaults to 'rt')
 
     Returns:
       File handle that can be used for read operations.

--- a/bcftbx/FASTQFile.py
+++ b/bcftbx/FASTQFile.py
@@ -99,7 +99,7 @@ class FastqIterator(Iterator):
         self.__fastq_file = fastq_file
         self.__bufsize = bufsize
         if fp is None:
-            self.__fp = get_fastq_file_handle(self.__fastq_file)
+            self.__fp = get_fastq_file_handle(self.__fastq_file,'rb')
         else:
             self.__fp = fp
         self._buf = ''
@@ -117,7 +117,7 @@ class FastqIterator(Iterator):
         # Do we already have a read to return?
         while len(lines) < 4:
             # Fetch more data
-            data = self.__fp.read(bufsize)
+            data = self.__fp.read(bufsize).decode()
             if not data:
                 # Reached EOF
                 if self.__fastq_file is None:

--- a/bcftbx/FASTQFile.py
+++ b/bcftbx/FASTQFile.py
@@ -124,7 +124,7 @@ class FastqIterator(Iterator):
                     self.__fp.close()
                 raise StopIteration
             # Add to buffer and split into lines
-            buf = buf + str(data)
+            buf = buf + data
             if buf[-1] != '\n':
                 i = buf.rfind('\n')
                 if i == -1:

--- a/bcftbx/test/test_FASTQFile.py
+++ b/bcftbx/test/test_FASTQFile.py
@@ -391,12 +391,36 @@ class TestFastqAttributes(unittest.TestCase):
 class TestNReads(unittest.TestCase):
     """Tests of the nreads function
     """
+    def setUp(self):
+        # Temporary working dir
+        self.wd = tempfile.mkdtemp(suffix='.TestNReads')
+
+    def tearDown(self):
+        # Remove temporary working dir
+        if os.path.isdir(self.wd):
+            shutil.rmtree(self.wd)
 
     def test_nreads(self):
-        """Check that nreads returns correct read count
+        """nreads: check that nreads returns correct read count
         """
         fp = io.StringIO(fastq_data)
         self.assertEqual(nreads(fp=fp),5)
+
+    def test_nreads_from_file_on_disk(self):
+        """nreads: check nreads from FASTQ on disk
+        """
+        self.fastq_in = os.path.join(self.wd,'test.fq')
+        with open(self.fastq_in,'w') as fp:
+            fp.write(fastq_data)
+        self.assertEqual(nreads(self.fastq_in),5)
+
+    def test_nreads_from_gzipped_file_on_disk(self):
+        """nreads: check nreads from gzipped FASTQ on disk
+        """
+        self.fastq_in = os.path.join(self.wd,'test.fq.gz')
+        with gzip.GzipFile(self.fastq_in,'wb') as fp:
+            fp.write(fastq_data.encode())
+        self.assertEqual(nreads(self.fastq_in),5)
 
 class TestFastqsArePair(unittest.TestCase):
     """Tests of the fastqs_are_pair function


### PR DESCRIPTION
PR which fixes various previously undiagnosed issues associated with `FastqIterator` and the `nreads` function in the `bcftbx/FASTQFile` module under Python3, when reading FASTQ data from files on disk (both uncompressed and gzipped).