### PR TITLE
JobRunner: enable slots/cores/threads to be set within runners

### DIFF
--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -254,12 +254,12 @@ class SimpleJobRunner(BaseJobRunner):
         if working_dir:
             # Move to working directory
             os.chdir(working_dir)
-        logging.debug("RunScript: command: %s" % cmd)
+        logging.debug("SimpleJobRunner: command: %s" % cmd)
         cwd = os.getcwd()
         # Check that this exists
-        logging.debug("RunScript: executing in %s" % cwd)
+        logging.debug("SimpleJobRunner: executing in %s" % cwd)
         if not os.path.exists(cwd):
-            logging.error("RunScript: cwd doesn't exist!")
+            logging.error("SimpleJobRunner: cwd doesn't exist!")
             return None
         # Set up log files
         lognames = self.__assign_log_files(name,working_dir)
@@ -275,7 +275,7 @@ class SimpleJobRunner(BaseJobRunner):
         p = subprocess.Popen(cmd,cwd=cwd,stdout=log,stderr=err,env=env)
         # Capture the job id from the output
         job_id = str(p.pid)
-        logging.debug("RunScript: done - job id = %s" % job_id)
+        logging.debug("SimpleJobRunner: done - job id = %s" % job_id)
         # Do internal house keeping
         self.__job_list.append(job_id)
         self.__log_files[job_id] = lognames[0]

--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -42,7 +42,7 @@ Simple usage example:
 Processes run using a job runner inherit the environment where the runner
 is created and executed.
 
-Additionally runners set the 'JOBRUNNER_NSLOTS' environment variable,
+Additionally runners set an 'BCFTBX_RUNNER_NSLOTS' environment variable,
 which is set to the number of slots (aka CPUs/cores/threads) available to
 processes executed by the runner. For both 'SimpleJobRunner' and
 'GEJobRunner', this defaults to one (i.e. serial jobs); the 'nslots'
@@ -270,7 +270,7 @@ class SimpleJobRunner(BaseJobRunner):
             err = subprocess.STDOUT
         # Set up the environment
         env = os.environ.copy()
-        env['JOBRUNNER_NSLOTS'] = "%s" % self.nslots
+        env['BCFTBX_RUNNER_NSLOTS'] = "%s" % self.nslots
         # Start the subprocess
         p = subprocess.Popen(cmd,cwd=cwd,stdout=log,stderr=err,env=env)
         # Capture the job id from the output
@@ -540,9 +540,9 @@ class GEJobRunner(BaseJobRunner):
         job_script = os.path.join(job_dir,"job_script.sh")
         with io.open(job_script,'wt') as fp:
             fp.write(u"""#!{shell}
-export JOBRUNNER_NSLOTS=$NSLOTS
+export BCFTBX_RUNNER_NSLOTS=$NSLOTS
 echo "$QUEUE" > {job_dir}/__queue
-echo "$JOBRUNNER_NSLOTS" > {job_dir}/__jobrunner_nslots
+echo "$BCFTBX_RUNNER_NSLOTS" > {job_dir}/__jobrunner_nslots
 {cmd}
 exit_code=$?
 echo "$exit_code" > {job_dir}/__exit_code.tmp

--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -39,6 +39,23 @@ Simple usage example:
 >>> # Get the names of the output files
 >>> log,err = (runner.logFile(job_id),runner.errFile(job_id))
 
+Processes run using a job runner inherit the environment where the runner
+is created and executed.
+
+Additionally runners set the 'JOBRUNNER_NSLOTS' environment variable,
+which is set to the number of slots (aka CPUs/cores/threads) available to
+processes executed by the runner. For both 'SimpleJobRunner' and
+'GEJobRunner', this defaults to one (i.e. serial jobs); the 'nslots'
+option can be used when instantiating 'SimpleJobRunner' objects to
+specify more cores, for example:
+
+>>> multicore_runner = SimpleJobRunner(nslots=4)
+
+For 'GEJobRunner' instances the number of cores is set by specifying
+'-pe smp.pe' as part of the 'ge_extra_args' option, for example:
+
+>>> multicore_runner = GEJobRunner(extra_ge_args=('-pe','smp.pe','4'))
+
 """
 
 #######################################################################

--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     JobRunner.py: classes for starting and managing job runs
-#     Copyright (C) University of Manchester 2011-2019 Peter Briggs
+#     Copyright (C) University of Manchester 2011-2020 Peter Briggs
 #
 ########################################################################
 #

--- a/bcftbx/test/test_JobRunner.py
+++ b/bcftbx/test/test_JobRunner.py
@@ -170,6 +170,31 @@ class TestSimpleJobRunner(unittest.TestCase):
         self.assertEqual(os.path.dirname(runner.logFile(jobid3)),self.log_dir)
         self.assertEqual(os.path.dirname(runner.errFile(jobid3)),self.log_dir)
 
+    def test_simple_job_runner_nslots(self):
+        """Test SimpleJobRunner setting nslots
+
+        """
+        # Create a runner and check default nslots
+        runner = SimpleJobRunner()
+        self.assertEqual(runner.nslots,1)
+        jobid = self.run_job(runner,
+                             'test',
+                             self.working_dir,
+                             '/bin/bash',('-c','echo $JOBRUNNER_NSLOTS',))
+        self.wait_for_jobs(runner,jobid)
+        with io.open(runner.logFile(jobid),'rt') as fp:
+            self.assertEqual(u"1\n",fp.read())
+        # Create a runner with multiple nslots
+        runner = SimpleJobRunner(nslots=8)
+        self.assertEqual(runner.nslots,8)
+        jobid = self.run_job(runner,
+                             'test',
+                             self.working_dir,
+                             '/bin/bash',('-c','echo $JOBRUNNER_NSLOTS',))
+        self.wait_for_jobs(runner,jobid)
+        with io.open(runner.logFile(jobid),'rt') as fp:
+            self.assertEqual(u"8\n",fp.read())
+
 class TestGEJobRunner(unittest.TestCase):
 
     def setUp(self):

--- a/bcftbx/test/test_JobRunner.py
+++ b/bcftbx/test/test_JobRunner.py
@@ -171,7 +171,7 @@ class TestSimpleJobRunner(unittest.TestCase):
         self.assertEqual(os.path.dirname(runner.errFile(jobid3)),self.log_dir)
 
     def test_simple_job_runner_nslots(self):
-        """Test SimpleJobRunner setting nslots
+        """Test SimpleJobRunner sets BCFTBX_RUNNER_NSLOTS
 
         """
         # Create a runner and check default nslots
@@ -180,7 +180,8 @@ class TestSimpleJobRunner(unittest.TestCase):
         jobid = self.run_job(runner,
                              'test',
                              self.working_dir,
-                             '/bin/bash',('-c','echo $JOBRUNNER_NSLOTS',))
+                             '/bin/bash',
+                             ('-c','echo $BCFTBX_RUNNER_NSLOTS',))
         self.wait_for_jobs(runner,jobid)
         with io.open(runner.logFile(jobid),'rt') as fp:
             self.assertEqual(u"1\n",fp.read())
@@ -190,7 +191,8 @@ class TestSimpleJobRunner(unittest.TestCase):
         jobid = self.run_job(runner,
                              'test',
                              self.working_dir,
-                             '/bin/bash',('-c','echo $JOBRUNNER_NSLOTS',))
+                             '/bin/bash',
+                             ('-c','echo $BCFTBX_RUNNER_NSLOTS',))
         self.wait_for_jobs(runner,jobid)
         with io.open(runner.logFile(jobid),'rt') as fp:
             self.assertEqual(u"8\n",fp.read())
@@ -494,7 +496,7 @@ class TestGEJobRunner(unittest.TestCase):
         self.assertEqual(runner.queue(jobid),"mock.q")
 
     def test_simple_job_runner_nslots(self):
-        """Test GEJobRunner sets JOBRUNNER_NSLOTS
+        """Test GEJobRunner sets BCFTBX_RUNNER_NSLOTS
         """
         # Create a runner and check default nslots
         runner = GEJobRunner()
@@ -502,7 +504,8 @@ class TestGEJobRunner(unittest.TestCase):
         jobid = self.run_job(runner,
                              'test',
                              self.working_dir,
-                             '/bin/bash',('-c','echo $JOBRUNNER_NSLOTS',))
+                             '/bin/bash',
+                             ('-c','echo $BCFTBX_RUNNER_NSLOTS',))
         self.wait_for_jobs(runner,jobid)
         with io.open(runner.logFile(jobid),'rt') as fp:
             self.assertEqual(u"1\n",fp.read())
@@ -512,7 +515,8 @@ class TestGEJobRunner(unittest.TestCase):
         jobid = self.run_job(runner,
                              'test',
                              self.working_dir,
-                             '/bin/bash',('-c','echo $JOBRUNNER_NSLOTS',))
+                             '/bin/bash',
+                             ('-c','echo $BCFTBX_RUNNER_NSLOTS',))
         self.wait_for_jobs(runner,jobid)
         with io.open(runner.logFile(jobid),'rt') as fp:
             self.assertEqual(u"8\n",fp.read())

--- a/bcftbx/test/test_JobRunner.py
+++ b/bcftbx/test/test_JobRunner.py
@@ -557,6 +557,14 @@ class TestFetchRunnerFunction(unittest.TestCase):
         """
         runner = fetch_runner("SimpleJobRunner")
         self.assertTrue(isinstance(runner,SimpleJobRunner))
+        self.assertEqual(runner.nslots,1)
+
+    def test_fetch_simple_job_runner_with_nslots(self):
+        """fetch_runner returns a SimpleJobRunner with nslots
+        """
+        runner = fetch_runner("SimpleJobRunner(nslots=8)")
+        self.assertTrue(isinstance(runner,SimpleJobRunner))
+        self.assertEqual(runner.nslots,8)
 
     def test_fetch_ge_job_runner(self):
         """fetch_runner returns a GEJobRunner

--- a/bcftbx/test/test_JobRunner.py
+++ b/bcftbx/test/test_JobRunner.py
@@ -493,6 +493,30 @@ class TestGEJobRunner(unittest.TestCase):
         # Check the queue
         self.assertEqual(runner.queue(jobid),"mock.q")
 
+    def test_simple_job_runner_nslots(self):
+        """Test GEJobRunner sets JOBRUNNER_NSLOTS
+        """
+        # Create a runner and check default nslots
+        runner = GEJobRunner()
+        self.assertEqual(runner.nslots,1)
+        jobid = self.run_job(runner,
+                             'test',
+                             self.working_dir,
+                             '/bin/bash',('-c','echo $JOBRUNNER_NSLOTS',))
+        self.wait_for_jobs(runner,jobid)
+        with io.open(runner.logFile(jobid),'rt') as fp:
+            self.assertEqual(u"1\n",fp.read())
+        # Create a runner with multiple nslots
+        runner = GEJobRunner(ge_extra_args=['-pe','smp.pe','8'])
+        self.assertEqual(runner.nslots,8)
+        jobid = self.run_job(runner,
+                             'test',
+                             self.working_dir,
+                             '/bin/bash',('-c','echo $JOBRUNNER_NSLOTS',))
+        self.wait_for_jobs(runner,jobid)
+        with io.open(runner.logFile(jobid),'rt') as fp:
+            self.assertEqual(u"8\n",fp.read())
+
 class TestResourceLock(unittest.TestCase):
     """
     Tests for the ResourceLock class


### PR DESCRIPTION
PR which enables the number of available threads or cores to be set and accessed from job runners.

For `SimpleJobRunner` instances, the `nslots` option can be set to specify the number of available cores; for `GEJobRunner` instances the number of available cores is determined at run time from the `NSLOTS` environment variable. Both runners set a `BCFTBX_RUNNER_NSLOTS` environment variable so that processes run by the runners can access and use this number if required. 