### PR TITLE
bcftbx/IlluminaData: 'SampleSheetPredictor' needs to handle blank lanes

### DIFF
--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -1,5 +1,5 @@
 #     IlluminaData.py: module for handling data about Illumina sequencer runs
-#     Copyright (C) University of Manchester 2012-2019 Peter Briggs
+#     Copyright (C) University of Manchester 2012-2020 Peter Briggs
 #
 ########################################################################
 #
@@ -1856,7 +1856,8 @@ class SampleSheetPredictor(object):
             sample_sheet = SampleSheet(sample_sheet_file)
         # Put data into lane order (if lanes specified)
         if sample_sheet.has_lanes:
-            sample_sheet.data.sort(lambda line: line['Lane'])
+            sample_sheet.data.sort(lambda line: line['Lane']
+                                   if line['Lane'] != '' else 99999)
         s_index = 0
         for line in sample_sheet:
             # Get project and sample info


### PR DESCRIPTION
PR which updates the `SampleSheetPredictor` class in `bcftbx/IlluminaData` to handle blank lane numbers in the input samplesheet.