### PR TITLE
htmlpagewriter: update 'PNGBase64Encoder' for Python 3 compatibility

### DIFF
--- a/bcftbx/htmlpagewriter.py
+++ b/bcftbx/htmlpagewriter.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     htmlpagewriter: programmatic generation of HTML files
-#     Copyright (C) University of Manchester 2012-2019 Peter Briggs
+#     Copyright (C) University of Manchester 2012-2020 Peter Briggs
 #
 ########################################################################
 #
@@ -9,7 +9,7 @@
 #
 #########################################################################
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 """htmlpagewriter
 

--- a/bcftbx/htmlpagewriter.py
+++ b/bcftbx/htmlpagewriter.py
@@ -164,4 +164,4 @@ class PNGBase64Encoder(object):
     def encodePNG(self,pngfile):
         """Return base64 string encoding a PNG file.
         """
-        return base64.b64encode(io.open(pngfile,'rb').read())
+        return base64.b64encode(io.open(pngfile,'rb').read()).decode()

--- a/bcftbx/test/test_htmlpagewriter.py
+++ b/bcftbx/test/test_htmlpagewriter.py
@@ -5,6 +5,8 @@ from bcftbx.htmlpagewriter import HTMLPageWriter
 from bcftbx.htmlpagewriter import PNGBase64Encoder
 import unittest
 import io
+import base64
+import tempfile
 
 class TestHTMLPageWriter(unittest.TestCase):
     """
@@ -95,4 +97,21 @@ body { color: blue; }</style>
 <p>We can see how well it works...</p></body>
 </html>
 """)
-        
+
+class TestPNGBase64Encoder(unittest.TestCase):
+    def setUp(self):
+        # Make a psuedo-PNG test file
+        data = b"PNG data"
+        with tempfile.NamedTemporaryFile(delete=False) as fp:
+            self.filen = fp.name
+            fp.write(data)
+        self.encoded_data = base64.b64encode(data)
+
+    def test_encodePNG(self):
+        self.assertEqual(self.encoded_data,
+                         PNGBase64Encoder().encodePNG(self.filen))
+
+    def test_encodePNG_insert_into_text(self):
+        self.assertEqual("the encoded text is: '%s'" % self.encoded_data,
+                         "the encoded text is: '%s'" %
+                         PNGBase64Encoder().encodePNG(self.filen))

--- a/bcftbx/test/test_htmlpagewriter.py
+++ b/bcftbx/test/test_htmlpagewriter.py
@@ -105,7 +105,7 @@ class TestPNGBase64Encoder(unittest.TestCase):
         with tempfile.NamedTemporaryFile(delete=False) as fp:
             self.filen = fp.name
             fp.write(data)
-        self.encoded_data = base64.b64encode(data)
+        self.encoded_data = base64.b64encode(data).decode()
 
     def test_encodePNG(self):
         self.assertEqual(self.encoded_data,


### PR DESCRIPTION
PR which adds unit tests for the `PNGBase64Encoder` class in `bcftbx/htmlpagewriter` and updates the output to ensure that unicode strings are returned (for compatibility with Python 3).