### PR TITLE
Extend supported Python 3 versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@
 language: python
 python:
   - "2.7"
+  - "3.6"
   - "3.7"
+  - "3.8"
 
 install:
   - "pip install ."

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,173 @@
-		       The Artistic License 2.0
+Licensed under the Academic Free License version 3.0
 
-	    Copyright (c) 2000-2006, The Perl Foundation.
+ 1) Grant of Copyright License. Licensor grants You a worldwide, royalty-free, 
+    non-exclusive, sublicensable license, for the duration of the copyright, to 
+    do the following:
 
-     Everyone is permitted to copy and distribute verbatim copies
-      of this license document, but changing it is not allowed.
+    a) to reproduce the Original Work in copies, either alone or as part of a 
+       collective work;
 
-Preamble
+    b) to translate, adapt, alter, transform, modify, or arrange the Original 
+       Work, thereby creating derivative works ("Derivative Works") based upon 
+       the Original Work;
 
-This license establishes the terms under which a given free software
-Package may be copied, modified, distributed, and/or redistributed.
-The intent is that the Copyright Holder maintains some artistic
-control over the development of that Package while still keeping the
-Package available as open source and free software.
+    c) to distribute or communicate copies of the Original Work and Derivative 
+       Works to the public, under any license of your choice that does not 
+       contradict the terms and conditions, including Licensor's reserved 
+       rights and remedies, in this Academic Free License;
 
-You are always permitted to make arrangements wholly outside of this
-license directly with the Copyright Holder of a given Package.  If the
-terms of this license do not permit the full use that you propose to
-make of the Package, you should contact the Copyright Holder and seek
-a different licensing arrangement. 
+    d) to perform the Original Work publicly; and
 
-Definitions
+    e) to display the Original Work publicly.
 
-    "Copyright Holder" means the individual(s) or organization(s)
-    named in the copyright notice for the entire Package.
+ 2) Grant of Patent License. Licensor grants You a worldwide, royalty-free, 
+    non-exclusive, sublicensable license, under patent claims owned or 
+    controlled by the Licensor that are embodied in the Original Work as 
+    furnished by the Licensor, for the duration of the patents, to make, use, 
+    sell, offer for sale, have made, and import the Original Work and 
+    Derivative Works.
 
-    "Contributor" means any party that has contributed code or other
-    material to the Package, in accordance with the Copyright Holder's
-    procedures.
+ 3) Grant of Source Code License. The term "Source Code" means the preferred 
+    form of the Original Work for making modifications to it and all available 
+    documentation describing how to modify the Original Work. Licensor agrees 
+    to provide a machine-readable copy of the Source Code of the Original Work 
+    along with each copy of the Original Work that Licensor distributes. 
+    Licensor reserves the right to satisfy this obligation by placing a 
+    machine-readable copy of the Source Code in an information repository 
+    reasonably calculated to permit inexpensive and convenient access by You 
+    for as long as Licensor continues to distribute the Original Work.
 
-    "You" and "your" means any person who would like to copy,
-    distribute, or modify the Package.
+ 4) Exclusions From License Grant. Neither the names of Licensor, nor the 
+    names of any contributors to the Original Work, nor any of their 
+    trademarks or service marks, may be used to endorse or promote products 
+    derived from this Original Work without express prior permission of the 
+    Licensor. Except as expressly stated herein, nothing in this License 
+    grants any license to Licensor's trademarks, copyrights, patents, trade 
+    secrets or any other intellectual property. No patent license is granted 
+    to make, use, sell, offer for sale, have made, or import embodiments of 
+    any patent claims other than the licensed claims defined in Section 2. 
+    No license is granted to the trademarks of Licensor even if such marks 
+    are included in the Original Work. Nothing in this License shall be 
+    interpreted to prohibit Licensor from licensing under terms different 
+    from this License any Original Work that Licensor otherwise would have a 
+    right to license.
 
-    "Package" means the collection of files distributed by the
-    Copyright Holder, and derivatives of that collection and/or of
-    those files. A given Package may consist of either the Standard
-    Version, or a Modified Version.
+ 5) External Deployment. The term "External Deployment" means the use, 
+    distribution, or communication of the Original Work or Derivative Works 
+    in any way such that the Original Work or Derivative Works may be used by 
+    anyone other than You, whether those works are distributed or 
+    communicated to those persons or made available as an application 
+    intended for use over a network. As an express condition for the grants 
+    of license hereunder, You must treat any External Deployment by You of 
+    the Original Work or a Derivative Work as a distribution under 
+    section 1(c).
 
-    "Distribute" means providing a copy of the Package or making it
-    accessible to anyone else, or in the case of a company or
-    organization, to others outside of your company or organization.
+ 6) Attribution Rights. You must retain, in the Source Code of any Derivative 
+    Works that You create, all copyright, patent, or trademark notices from 
+    the Source Code of the Original Work, as well as any notices of licensing 
+    and any descriptive text identified therein as an "Attribution Notice." 
+    You must cause the Source Code for any Derivative Works that You create 
+    to carry a prominent Attribution Notice reasonably calculated to inform 
+    recipients that You have modified the Original Work.
 
-    "Distributor Fee" means any fee that you charge for Distributing
-    this Package or providing support for this Package to another
-    party.  It does not mean licensing fees.
+ 7) Warranty of Provenance and Disclaimer of Warranty. Licensor warrants that 
+    the copyright in and to the Original Work and the patent rights granted 
+    herein by Licensor are owned by the Licensor or are sublicensed to You 
+    under the terms of this License with the permission of the contributor(s) 
+    of those copyrights and patent rights. Except as expressly stated in the 
+    immediately preceding sentence, the Original Work is provided under this 
+    License on an "AS IS" BASIS and WITHOUT WARRANTY, either express or 
+    implied, including, without limitation, the warranties of 
+    non-infringement, merchantability or fitness for a particular purpose. 
+    THE ENTIRE RISK AS TO THE QUALITY OF THE ORIGINAL WORK IS WITH YOU. This 
+    DISCLAIMER OF WARRANTY constitutes an essential part of this License. 
+    No license to the Original Work is granted by this License except under 
+    this disclaimer.
 
-    "Standard Version" refers to the Package if it has not been
-    modified, or has been modified only in ways explicitly requested
-    by the Copyright Holder.
+ 8) Limitation of Liability. Under no circumstances and under no legal 
+    theory, whether in tort (including negligence), contract, or otherwise, 
+    shall the Licensor be liable to anyone for any indirect, special, 
+    incidental, or consequential damages of any character arising as a result 
+    of this License or the use of the Original Work including, without 
+    limitation, damages for loss of goodwill, work stoppage, computer failure 
+    or malfunction, or any and all other commercial damages or losses. This 
+    limitation of liability shall not apply to the extent applicable law 
+    prohibits such limitation.
 
-    "Modified Version" means the Package, if it has been changed, and
-    such changes were not explicitly requested by the Copyright
-    Holder. 
+ 9) Acceptance and Termination. If, at any time, You expressly assented to 
+    this License, that assent indicates your clear and irrevocable acceptance 
+    of this License and all of its terms and conditions. If You distribute or 
+    communicate copies of the Original Work or a Derivative Work, You must 
+    make a reasonable effort under the circumstances to obtain the express 
+    assent of recipients to the terms of this License. This License 
+    conditions your rights to undertake the activities listed in Section 1, 
+    including your right to create Derivative Works based upon the Original 
+    Work, and doing so without honoring these terms and conditions is 
+    prohibited by copyright law and international treaty. Nothing in this 
+    License is intended to affect copyright exceptions and limitations 
+    (including "fair use" or "fair dealing"). This License shall terminate 
+    immediately and You may no longer exercise any of the rights granted to 
+    You by this License upon your failure to honor the conditions in 
+    Section 1(c).
 
-    "Original License" means this Artistic License as Distributed with
-    the Standard Version of the Package, in its current version or as
-    it may be modified by The Perl Foundation in the future.
+10) Termination for Patent Action. This License shall terminate 
+    automatically and You may no longer exercise any of the rights granted 
+    to You by this License as of the date You commence an action, including 
+    a cross-claim or counterclaim, against Licensor or any licensee alleging 
+    that the Original Work infringes a patent. This termination provision 
+    shall not apply for an action alleging patent infringement by 
+    combinations of the Original Work with other software or hardware.
 
-    "Source" form means the source code, documentation source, and
-    configuration files for the Package.
+11) Jurisdiction, Venue and Governing Law. Any action or suit relating to 
+    this License may be brought only in the courts of a jurisdiction wherein 
+    the Licensor resides or in which Licensor conducts its primary business, 
+    and under the laws of that jurisdiction excluding its conflict-of-law 
+    provisions. The application of the United Nations Convention on 
+    Contracts for the International Sale of Goods is expressly excluded. Any 
+    use of the Original Work outside the scope of this License or after its 
+    termination shall be subject to the requirements and penalties of 
+    copyright or patent law in the appropriate jurisdiction. This section 
+    shall survive the termination of this License.
 
-    "Compiled" form means the compiled bytecode, object code, binary,
-    or any other form resulting from mechanical transformation or
-    translation of the Source form.
+12) Attorneys' Fees. In any action to enforce the terms of this License or 
+    seeking damages relating thereto, the prevailing party shall be entitled 
+    to recover its costs and expenses, including, without limitation, 
+    reasonable attorneys' fees and costs incurred in connection with such 
+    action, including any appeal of such action. This section shall survive 
+    the termination of this License.
 
+13) Miscellaneous. If any provision of this License is held to be 
+    unenforceable, such provision shall be reformed only to the extent 
+    necessary to make it enforceable.
 
-Permission for Use and Modification Without Distribution
+14) Definition of "You" in This License. "You" throughout this License, 
+    whether in upper or lower case, means an individual or a legal entity 
+    exercising rights under, and complying with all of the terms of, this 
+    License. For legal entities, "You" includes any entity that controls, is 
+    controlled by, or is under common control with you. For purposes of this 
+    definition, "control" means (i) the power, direct or indirect, to cause 
+    the direction or management of such entity, whether by contract or 
+    otherwise, or (ii) ownership of fifty percent (50%) or more of the 
+    outstanding shares, or (iii) beneficial ownership of such entity.
 
-(1)  You are permitted to use the Standard Version and create and use
-Modified Versions for any purpose without restriction, provided that
-you do not Distribute the Modified Version.
+15) Right to Use. You may use the Original Work in all ways not otherwise 
+    restricted or conditioned by this License or by law, and Licensor 
+    promises not to interfere with or be responsible for such uses by You.
 
-
-Permissions for Redistribution of the Standard Version
-
-(2)  You may Distribute verbatim copies of the Source form of the
-Standard Version of this Package in any medium without restriction,
-either gratis or for a Distributor Fee, provided that you duplicate
-all of the original copyright notices and associated disclaimers.  At
-your discretion, such verbatim copies may or may not include a
-Compiled form of the Package.
-
-(3)  You may apply any bug fixes, portability changes, and other
-modifications made available from the Copyright Holder.  The resulting
-Package will still be considered the Standard Version, and as such
-will be subject to the Original License.
-
-
-Distribution of Modified Versions of the Package as Source 
-
-(4)  You may Distribute your Modified Version as Source (either gratis
-or for a Distributor Fee, and with or without a Compiled form of the
-Modified Version) provided that you clearly document how it differs
-from the Standard Version, including, but not limited to, documenting
-any non-standard features, executables, or modules, and provided that
-you do at least ONE of the following:
-
-    (a)  make the Modified Version available to the Copyright Holder
-    of the Standard Version, under the Original License, so that the
-    Copyright Holder may include your modifications in the Standard
-    Version.
-
-    (b)  ensure that installation of your Modified Version does not
-    prevent the user installing or running the Standard Version. In
-    addition, the Modified Version must bear a name that is different
-    from the name of the Standard Version.
-
-    (c)  allow anyone who receives a copy of the Modified Version to
-    make the Source form of the Modified Version available to others
-    under
-		
-	(i)  the Original License or
-
-	(ii)  a license that permits the licensee to freely copy,
-	modify and redistribute the Modified Version using the same
-	licensing terms that apply to the copy that the licensee
-	received, and requires that the Source form of the Modified
-	Version, and of any works derived from it, be made freely
-	available in that license fees are prohibited but Distributor
-	Fees are allowed.
-
-
-Distribution of Compiled Forms of the Standard Version 
-or Modified Versions without the Source
-
-(5)  You may Distribute Compiled forms of the Standard Version without
-the Source, provided that you include complete instructions on how to
-get the Source of the Standard Version.  Such instructions must be
-valid at the time of your distribution.  If these instructions, at any
-time while you are carrying out such distribution, become invalid, you
-must provide new instructions on demand or cease further distribution.
-If you provide valid instructions or cease distribution within thirty
-days after you become aware that the instructions are invalid, then
-you do not forfeit any of your rights under this license.
-
-(6)  You may Distribute a Modified Version in Compiled form without
-the Source, provided that you comply with Section 4 with respect to
-the Source of the Modified Version.
-
-
-Aggregating or Linking the Package 
-
-(7)  You may aggregate the Package (either the Standard Version or
-Modified Version) with other packages and Distribute the resulting
-aggregation provided that you do not charge a licensing fee for the
-Package.  Distributor Fees are permitted, and licensing fees for other
-components in the aggregation are permitted. The terms of this license
-apply to the use and Distribution of the Standard or Modified Versions
-as included in the aggregation.
-
-(8) You are permitted to link Modified and Standard Versions with
-other works, to embed the Package in a larger work of your own, or to
-build stand-alone binary or bytecode versions of applications that
-include the Package, and Distribute the result without restriction,
-provided the result does not expose a direct interface to the Package.
-
-
-Items That are Not Considered Part of a Modified Version 
-
-(9) Works (including, but not limited to, modules and scripts) that
-merely extend or make use of the Package, do not, by themselves, cause
-the Package to be a Modified Version.  In addition, such works are not
-considered parts of the Package itself, and are not subject to the
-terms of this license.
-
-
-General Provisions
-
-(10)  Any use, modification, and distribution of the Standard or
-Modified Versions is governed by this Artistic License. By using,
-modifying or distributing the Package, you accept this license. Do not
-use, modify, or distribute the Package, if you do not accept this
-license.
-
-(11)  If your Modified Version has been derived from a Modified
-Version made by someone other than you, you are nevertheless required
-to ensure that your Modified Version complies with the requirements of
-this license.
-
-(12)  This license does not grant you the right to use any trademark,
-service mark, tradename, or logo of the Copyright Holder.
-
-(13)  This license includes the non-exclusive, worldwide,
-free-of-charge patent license to make, have made, use, offer to sell,
-sell, import and otherwise transfer the Package with respect to any
-patent claims licensable by the Copyright Holder that are necessarily
-infringed by the Package. If you institute patent litigation
-(including a cross-claim or counterclaim) against any party alleging
-that the Package constitutes direct or contributory patent
-infringement, then this Artistic License to you shall terminate on the
-date that such litigation is filed.
-
-(14)  Disclaimer of Warranty:
-THE PACKAGE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS "AS
-IS' AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES. THE IMPLIED
-WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR
-NON-INFRINGEMENT ARE DISCLAIMED TO THE EXTENT PERMITTED BY YOUR LOCAL
-LAW. UNLESS REQUIRED BY LAW, NO COPYRIGHT HOLDER OR CONTRIBUTOR WILL
-BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
-DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THE PACKAGE, EVEN IF
-ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+16) Modification of This License. This License is Copyright © 2005 Lawrence 
+    Rosen. Permission is granted to copy, distribute, or communicate this 
+    License without modification. Nothing in this License permits You to 
+    modify this License as applied to the Original Work or to Derivative 
+    Works. However, You may modify the text of this License and copy, 
+    distribute or communicate your modified version (the "Modified 
+    License") and apply it to other original works of authorship subject to 
+    the following conditions: (i) You may not indicate in any way that your 
+    Modified License is the "Academic Free License" or "AFL" and you may not 
+    use those names in the name of your Modified License; (ii) You must 
+    replace the notice specified in the first paragraph above with the 
+    notice "Licensed under <insert your license name here>" or with a notice 
+    of your own that is not confusingly similar to the notice in this 
+    License; and (iii) You may not claim that your original works are open 
+    source software unless your Modified License has been approved by Open 
+    Source Initiative (OSI) and You comply with its license review and 
+    certification process.

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -4,22 +4,31 @@ Installation and set up
 Installing the genomics/bcftbx package
 **************************************
 
-It is recommended to install directly from github using ``pip``::
+Currently it is recommended to install ``genomics-bcftbx`` from Github
+into a Python virtual environment, for example:
 
-    pip install git+https://github.com/fls-bioinformatics-core/genomics.git
+::
+   
+    virtualenv venv
+    . venv/bin/activate
+    pip install https://github.com/fls-bioinformatics-core/genomics/archive/1.8.3.tar.gz
 
-from within the top-level source directory to install the package.
-
-To use the package without installing it first you will need to add the
-directory to your ``PYTHONPATH`` environment, and reference the scripts and
-programs using their full paths.
+The list of available releases can be found at https://github.com/fls-bioinformatics-core/genomics/releases
 
 
 Dependencies
 ************
 
-The package consists predominantly of code written in Python, which has been
-used extensively with Python 2.6 and 2.7.
+The package consists predominantly of code written in Python, and the
+following versions are supported:
+
+* Python 2.7
+* Python 3.6
+* Python 3.7
+* Python 3.8
+
+However as Python 2.7 is now end-of-life, support within ``genomics-bcftbx``
+will be withdrawn for this version in the near future.
 
 In addition there are scripts requiring:
 
@@ -126,8 +135,8 @@ for colorspace. (In each case the path is the base name for the index files.)
 
 .. _qc_setup:
 
-Create `qc.setup`
-*****************
+Create ``qc.setup``
+*******************
 
 When the package is installed a template ``qc.setup.sample`` file is
 created in the ``config`` subdirectory - it needs to be copied to ``qc.setup``

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 Setup script to install genomics/bcftbx
 
-Copyright (C) University of Manchester 2011-15 Peter Briggs
+Copyright (C) University of Manchester 2011-20 Peter Briggs
 
 """
 
@@ -34,7 +34,7 @@ setup(name = "genomics-bcftbx",
       maintainer = 'Peter Briggs',
       maintainer_email = 'peter.briggs@manchester.ac.uk',
       packages = ['bcftbx','bcftbx.qc'],
-      license = 'Artistic License',
+      license = 'AFL-3',
       # Pull in dependencies
       install_requires = ['xlwt >= 0.7.2',
                           'xlrd >= 0.7.1',
@@ -56,5 +56,23 @@ setup(name = "genomics-bcftbx",
                      ['QC-pipeline/qc_boxplotter/colour_QC_script.sh',
                       'QC-pipeline/qc_boxplotter/qual2Rinput_file_per_posn.pl',
                       'QC-pipeline/qc_boxplotter/SOLiD_qual_boxplot.R'])],
+      classifiers=[
+          "Development Status :: 4 - Beta",
+          "Environment :: Console",
+          "Intended Audience :: End Users/Desktop",
+          "Intended Audience :: Science/Research",
+          "Intended Audience :: Developers",
+          "License :: OSI Approved :: Academic Free License (AFL)",
+          "Operating System :: POSIX :: Linux",
+          "Operating System :: MacOS",
+          "Topic :: Scientific/Engineering",
+          "Topic :: Scientific/Engineering :: Bio-Informatics",
+          "Programming Language :: Python :: 2",
+          "Programming Language :: Python :: 2.7"
+          "Programming Language :: Python :: 3",
+          'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: 3.7',
+          'Programming Language :: Python :: 3.8',
+      ],
       include_package_data=True,
       zip_safe = False)


### PR DESCRIPTION
PR which extends the specific versions of Python which are supported/tested to include 3.6 and 3.8.

Also updates `setup.py` to include the supported versions and adds an explicit license (AFL-3).