### PR TITLE
bcftbx/htmlpagewriter: remove unused imports

### DIFF
--- a/bcftbx/htmlpagewriter.py
+++ b/bcftbx/htmlpagewriter.py
@@ -27,8 +27,6 @@ import logging
 import xml.dom.minidom
 import shutil
 import base64
-from . import platforms
-from . import TabFile
 
 #######################################################################
 # Classes


### PR DESCRIPTION
PR which removes imports of the unused `platforms` and `TabFile` modules from the `htmlpagewriter` module of `bcftbx`.