### PR TITLE
bcftbx: fix 'ResourceWarnings' for unit tests run under Python 3

### DIFF
--- a/bcftbx/FASTQFile.py
+++ b/bcftbx/FASTQFile.py
@@ -118,7 +118,7 @@ class FastqIterator(Iterator):
             data = self.__fp.read(bufsize)
             if not data:
                 # Reached EOF
-                if self.__fastq_file is None:
+                if self.__fastq_file is not None:
                     self.__fp.close()
                 raise StopIteration
             # Add to buffer and split into lines

--- a/bcftbx/Md5sum.py
+++ b/bcftbx/Md5sum.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     Md5sum.py: classes and functions for md5 checksum operations
-#     Copyright (C) University of Manchester 2012-2019 Peter Briggs
+#     Copyright (C) University of Manchester 2012-2020 Peter Briggs
 #
 ########################################################################
 #
@@ -463,13 +463,7 @@ def md5sum(f):
     """Return md5sum digest for a file or stream
     
     This implements the md5sum checksum generation using both
-    the hashlib module (which should be available in Python 2.5) and
-    the deprecated md5 module (which will be used if hashlib is
-    unavailable, as is the case for Python 2.4 and earlier).
-
-    The choice of hashlib versus md5 is made automatically and there
-    is no need for the invoking subprogram to decide: the resulting
-    checksums are the same using either library regardless.
+    the hashlib module.
 
     Arguments:
       f: name of the file to generate the checksum from, or

--- a/bcftbx/Md5sum.py
+++ b/bcftbx/Md5sum.py
@@ -480,8 +480,10 @@ def md5sum(f):
 
     """
     chksum = hashlib.md5()
+    close_fp = False
     try:
         fp = io.open(f,"rb",buffering=BLOCKSIZE)
+        close_fp = True
     except TypeError:
         fp = f
     for block in iter(fp.read,''):
@@ -489,4 +491,6 @@ def md5sum(f):
             chksum.update(block)
         else:
             break
+    if close_fp:
+        fp.close()
     return chksum.hexdigest()

--- a/bcftbx/htmlpagewriter.py
+++ b/bcftbx/htmlpagewriter.py
@@ -160,4 +160,5 @@ class PNGBase64Encoder(object):
     def encodePNG(self,pngfile):
         """Return base64 string encoding a PNG file.
         """
-        return base64.b64encode(io.open(pngfile,'rb').read()).decode()
+        with io.open(pngfile,'rb') as png:
+            return base64.b64encode(png.read()).decode()

--- a/bcftbx/test/test_JobRunner.py
+++ b/bcftbx/test/test_JobRunner.py
@@ -218,6 +218,7 @@ class TestGEJobRunner(unittest.TestCase):
         self.ge_extra_args = []
 
     def tearDown(self):
+        self.mock_ge.stop()
         os.environ['PATH'] = self.old_path
         shutil.rmtree(self.database_dir)
         shutil.rmtree(self.bin_dir)
@@ -495,7 +496,7 @@ class TestGEJobRunner(unittest.TestCase):
         # Check the queue
         self.assertEqual(runner.queue(jobid),"mock.q")
 
-    def test_simple_job_runner_nslots(self):
+    def test_ge_job_runner_nslots(self):
         """Test GEJobRunner sets BCFTBX_RUNNER_NSLOTS
         """
         # Create a runner and check default nslots

--- a/bcftbx/test/test_Md5sum.py
+++ b/bcftbx/test/test_Md5sum.py
@@ -18,9 +18,8 @@ class TestMd5sum(unittest.TestCase):
         # mkstemp returns a tuple
         tmpfile = tempfile.mkstemp()
         self.filen = tmpfile[1]
-        fp = io.open(self.filen,'wt')
-        fp.write(TEST_TEXT)
-        fp.close()
+        with io.open(self.filen,'wt') as fp:
+            fp.write(TEST_TEXT)
 
     def tearDown(self):
         os.remove(self.filen)
@@ -34,9 +33,9 @@ class TestMd5sum(unittest.TestCase):
     def test_md5sum_for_stream(self):
         """md5sum function generates correct MD5 hash for stream
         """
-        fp = io.open(self.filen,'rb')
-        self.assertEqual(md5sum(fp),
-                         '08a6facee51e5435b9ef3744bd4dd5dc')
+        with io.open(self.filen,'rb') as fp:
+            self.assertEqual(md5sum(fp),
+                             '08a6facee51e5435b9ef3744bd4dd5dc')
 
     def test_no_file_name(self):
         """md5sum function handles 'None' as input file name

--- a/bcftbx/test/test_TabFile.py
+++ b/bcftbx/test/test_TabFile.py
@@ -72,7 +72,8 @@ chr2\t1234\t5678\t6.8
         tabfile = TabFile(fp=self.fp)
         out_file = os.path.join(self.working_dir,"test.tsv")
         tabfile.write(filen=out_file)
-        self.assertEqual(io.open(out_file,'rt').read(),self.data)
+        with io.open(out_file,'rt') as fp:
+            self.assertEqual(fp.read(),self.data)
 
     def test_write_data_to_file_include_header(self):
         """Write data to file including header
@@ -80,8 +81,8 @@ chr2\t1234\t5678\t6.8
         tabfile = TabFile(fp=self.fp,first_line_is_header=True)
         out_file = os.path.join(self.working_dir,"test.tsv")
         tabfile.write(filen=out_file,include_header=True)
-        self.assertEqual(io.open(out_file,'rt').read(),
-                         self.header+self.data)
+        with io.open(out_file,'rt') as fp:
+            self.assertEqual(fp.read(),self.header+self.data)
 
     def test_load_data_with_header(self):
         """Create and load Tabfile using first line as header

--- a/bcftbx/test/test_utils.py
+++ b/bcftbx/test/test_utils.py
@@ -544,7 +544,8 @@ class TestListDirsFunction(unittest.TestCase):
 
     def touch_file(self,name):
         # Add an empty file
-        io.open(os.path.join(self.parent_dir,name),'wt').close()
+        with io.open(os.path.join(self.parent_dir,name),'wt') as fp:
+            fp.write('')
 
     def test_empty_dir(self):
         """list_dirs returns empty list when listing empty directory
@@ -706,7 +707,8 @@ class TestChmodFunction(unittest.TestCase):
         """Check chmod works on a file
         """
         test_file = os.path.join(self.test_dir,'test.txt')
-        io.open(test_file,'wt').write(u"Some random text")
+        with io.open(test_file,'wt') as fp:
+            fp.write(u"Some random text")
         chmod(test_file,0o644)
         self.assertEqual(stat.S_IMODE(os.lstat(test_file).st_mode),0o644)
         chmod(test_file,0o755)
@@ -726,7 +728,8 @@ class TestChmodFunction(unittest.TestCase):
         """Check chmod doesn't follow symbolic links
         """
         test_file = os.path.join(self.test_dir,'test.txt')
-        io.open(test_file,'w').write(u"Some random text")
+        with io.open(test_file,'w') as fp:
+            fp.write(u"Some random text")
         test_link = os.path.join(self.test_dir,'test.lnk')
         os.symlink(test_file,test_link)
         chmod(test_file,0o644)
@@ -1047,7 +1050,8 @@ NATAAATCACCTCACTTAAGTGGCTGGAGACAAATA
                                 [self.fastq1,self.fastq2],
                                 overwrite=True,
                                 verbose=False)
-        merged_fastq_data = io.open(self.merged_fastq,'rt').read()
+        with io.open(self.merged_fastq,'rt') as fp:
+            merged_fastq_data = fp.read()
         self.assertEqual(merged_fastq_data,self.fastq_data1+self.fastq_data2)
 
     def test_concatenate_fastq_files_gzipped(self):

--- a/bcftbx/test/test_utils.py
+++ b/bcftbx/test/test_utils.py
@@ -545,7 +545,7 @@ class TestListDirsFunction(unittest.TestCase):
     def touch_file(self,name):
         # Add an empty file
         with io.open(os.path.join(self.parent_dir,name),'wt') as fp:
-            fp.write('')
+            fp.write(u'')
 
     def test_empty_dir(self):
         """list_dirs returns empty list when listing empty directory

--- a/bcftbx/utils.py
+++ b/bcftbx/utils.py
@@ -238,36 +238,36 @@ def getlines(filen):
         newline character removed.
     """
     if filen.split('.')[-1] == 'gz':
-        fp = gzip.open(filen,'rb')
+        open_ = gzip.open
     else:
-        fp = io.open(filen,'rb')
+        open_ = io.open
     # Read in data in chunks
     buf = ''
     lines = []
-    while True:
-        # Grab a chunk of data
-        data = fp.read(CHUNKSIZE).decode("UTF-8")
-        # Check for EOF
-        if not data:
-            fp.close()
-            break
-        # Add to buffer and split into lines
-        buf = buf + data
-        if buf[0] == '\n':
-            buf = buf[1:]
-        if buf[-1] != '\n':
-            i = buf.rfind('\n')
-            if i == -1:
-                continue
+    with open_(filen,'rb') as fp:
+        while True:
+            # Grab a chunk of data
+            data = fp.read(CHUNKSIZE).decode("UTF-8")
+            # Check for EOF
+            if not data:
+                break
+            # Add to buffer and split into lines
+            buf = buf + data
+            if buf[0] == '\n':
+                buf = buf[1:]
+            if buf[-1] != '\n':
+                i = buf.rfind('\n')
+                if i == -1:
+                    continue
+                else:
+                    lines = buf[:i].split('\n')
+                    buf = buf[i+1:]
             else:
-                lines = buf[:i].split('\n')
-                buf = buf[i+1:]
-        else:
-            lines = buf[:-1].split('\n')
-            buf = ''
-        # Return the lines one at a time
-        for line in lines:
-            yield line
+                lines = buf[:-1].split('\n')
+                buf = ''
+            # Return the lines one at a time
+            for line in lines:
+                yield line
 
 #######################################################################
 # File system wrappers and utilities

--- a/bcftbx/utils.py
+++ b/bcftbx/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     utils.py: utility classes and functions shared between BCF codes
-#     Copyright (C) University of Manchester 2013-2019 Peter Briggs
+#     Copyright (C) University of Manchester 2013-2020 Peter Briggs
 #
 ########################################################################
 #
@@ -249,6 +249,7 @@ def getlines(filen):
         data = fp.read(CHUNKSIZE).decode("UTF-8")
         # Check for EOF
         if not data:
+            fp.close()
             break
         # Add to buffer and split into lines
         buf = buf + data


### PR DESCRIPTION
PR which fixes `ResourceWarning` warnings from the unit tests when run under Python 3. The warnings are related to things like unclosed files and processes that are still running when the Python process ends, both in test cases and in the `bcftbx` code.