### PR TITLE
bcftbx/JobRunner: fix typo in 'os.getcwd()' call in 'SimpleJobRunner'

### DIFF
--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -262,7 +262,7 @@ class SimpleJobRunner(BaseJobRunner):
                               "exist!" % working_dir)
                 return None
         else:
-            working_dir = os.get_cwd()
+            working_dir = os.getcwd()
         logging.debug("SimpleJobRunner: executing in %s" % working_dir)
         # Set up log files
         lognames = self.__assign_log_files(name,working_dir)


### PR DESCRIPTION
Bugfix PR which corrects a typo in the `SimpleJobRunner` class (in the `bcftbx/JobRunner` module), where `os.getcwd()` was incorrectly called as `os.get_cwd()`.