### PR TITLE
SimpleJobRunner: update '__repr__' and 'fetch runner' for joining logs

### DIFF
--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -231,8 +231,7 @@ class SimpleJobRunner(BaseJobRunner):
         args = []
         if self.__nslots > 1:
             args.append('nslots=%s' % self.__nslots)
-        if self.__join_logs:
-            args.append('join_logs=True')
+        args.append('join_logs=%s' % self.__join_logs)
         if args:
             name += '(%s)' % ' '.join(args)
         return name

--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -227,7 +227,15 @@ class SimpleJobRunner(BaseJobRunner):
         self.__job_lock = ResourceLock()
 
     def __repr__(self):
-        return 'SimpleJobRunner'
+        name = 'SimpleJobRunner'
+        args = []
+        if self.__nslots > 1:
+            args.append('nslots=%s' % self.__nslots)
+        if self.__join_logs:
+            args.append('join_logs=True')
+        if args:
+            name += '(%s)' % ' '.join(args)
+        return name
 
     def run(self,name,working_dir,script,args):
         """Run a command and return the PID (=job id)

--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -1334,9 +1334,14 @@ def fetch_runner(definition):
     RunnerName can be 'SimpleJobRunner' or 'GEJobRunner'.
     If '(args)' are also supplied then:
 
-    - for SimpleJobRunners, this can be a single optional
-      argument of the form 'nslots=N' (where N is an integer);
-      use this to set a non-default number of slots
+    - for SimpleJobRunners, this can be a list of optional
+      arguments separated by spaces:
+      * 'nslots=N' (where N is an integer; sets a non-default
+        number of slots
+      * 'join_logs=BOOLEAN' (where BOOLEAN can be 'True',
+        'true','y','False','false','n'; sets whether stdout
+        and stderr should be written to the same file)
+
     - for GEJobRunners, this is a set of arbitrary 'qsub'
       options that will be used on job submission.
 
@@ -1346,12 +1351,23 @@ def fetch_runner(definition):
            definition.endswith(')'):
             args = definition[len('SimpleJobRunner('):len(definition)-1].split(' ')
             nslots = 1
+            join_logs=True
             for arg in args:
                 if arg.startswith("nslots="):
                     nslots = int(arg.split('=')[-1])
+                elif arg.startswith("join_logs="):
+                    join_logs = arg.split('=')[-1].lower()
+                    if join_logs in ('true','yes','y'):
+                        join_logs = True
+                    elif join_logs in ('false','no','n'):
+                        join_logs = False
+                    else:
+                        raise Exception("Invalid value for SimpleJobRunner "
+                                        "'join_logs': %s" % join_logs)
                 else:
-                    raise Exception("Unrecognised argument for SimpleJobRunner definition: %s" % arg)
-            return SimpleJobRunner(join_logs=True,nslots=nslots)
+                    raise Exception("Unrecognised argument for "
+                                    "SimpleJobRunner definition: %s" % arg)
+            return SimpleJobRunner(join_logs=join_logs,nslots=nslots)
         else:
             return SimpleJobRunner(join_logs=True)
     elif definition.startswith('GEJobRunner'):

--- a/bcftbx/test/test_JobRunner.py
+++ b/bcftbx/test/test_JobRunner.py
@@ -582,6 +582,13 @@ class TestFetchRunnerFunction(unittest.TestCase):
         self.assertTrue(isinstance(runner,SimpleJobRunner))
         self.assertEqual(runner.nslots,8)
 
+    def test_fetch_simple_job_runner_with_join_logs(self):
+        """fetch_runner returns a SimpleJobRunner with join_logs
+        """
+        runner = fetch_runner("SimpleJobRunner(join_logs=False)")
+        self.assertTrue(isinstance(runner,SimpleJobRunner))
+        self.assertEqual(runner.nslots,1)
+
     def test_fetch_ge_job_runner(self):
         """fetch_runner returns a GEJobRunner
         """

--- a/bcftbx/test/test_JobRunner.py
+++ b/bcftbx/test/test_JobRunner.py
@@ -197,6 +197,17 @@ class TestSimpleJobRunner(unittest.TestCase):
         with io.open(runner.logFile(jobid),'rt') as fp:
             self.assertEqual(u"8\n",fp.read())
 
+    def test_simple_job_runner_repr(self):
+        """Test SimpleJobRunner '__repr__' built-in
+        """
+        self.assertEqual(str(SimpleJobRunner()),'SimpleJobRunner')
+        self.assertEqual(str(SimpleJobRunner(nslots=8)),
+                             'SimpleJobRunner(nslots=8)')
+        self.assertEqual(str(SimpleJobRunner(join_logs=True)),
+                             'SimpleJobRunner(join_logs=True)')
+        self.assertEqual(str(SimpleJobRunner(nslots=8,join_logs=True)),
+                             'SimpleJobRunner(nslots=8 join_logs=True)')
+
 class TestGEJobRunner(unittest.TestCase):
 
     def setUp(self):

--- a/bcftbx/test/test_JobRunner.py
+++ b/bcftbx/test/test_JobRunner.py
@@ -200,13 +200,14 @@ class TestSimpleJobRunner(unittest.TestCase):
     def test_simple_job_runner_repr(self):
         """Test SimpleJobRunner '__repr__' built-in
         """
-        self.assertEqual(str(SimpleJobRunner()),'SimpleJobRunner')
+        self.assertEqual(str(SimpleJobRunner()),
+                         'SimpleJobRunner(join_logs=False)')
         self.assertEqual(str(SimpleJobRunner(nslots=8)),
-                             'SimpleJobRunner(nslots=8)')
+                         'SimpleJobRunner(nslots=8 join_logs=False)')
         self.assertEqual(str(SimpleJobRunner(join_logs=True)),
-                             'SimpleJobRunner(join_logs=True)')
+                         'SimpleJobRunner(join_logs=True)')
         self.assertEqual(str(SimpleJobRunner(nslots=8,join_logs=True)),
-                             'SimpleJobRunner(nslots=8 join_logs=True)')
+                         'SimpleJobRunner(nslots=8 join_logs=True)')
 
 class TestGEJobRunner(unittest.TestCase):
 


### PR DESCRIPTION
PR which updates the `SimpleJobRunner.__repr__` built-in function (in `bcftbx/JobRunners`) so that it includes the `nslots` and `join_logs` settings, for example:

    str(SimpleJobRunner(nslots=8,join_logs=True)

should return

    'SimpleJobRunner(nslots=8 join_logs=True)'

The PR also updates the `fetch_runner` function to handle the `join_logs` setting for `SimpleJobRunners` if it is supplied as part of the runner definition; this should mean that feeding the result of `__repr__` into `fetch_runner` will return a runner with the same configuration.