### PR TITLE
bcftbx/IlluminaData: remove trailing empty lines in 'SampleSheet' class

### DIFF
--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -1044,6 +1044,11 @@ class SampleSheet(object):
             for i,line in enumerate(self._data):
                 if str(line).startswith('#'):
                     del(self._data[i])
+            # Remove empty trailing lines
+            while len(self._data):
+                if ''.join([str(x) for x in self._data[-1]]):
+                    break
+                del(self._data[-1])
         # Guess the format if not already set
         if self._format is None:
             if not self._header and \

--- a/bcftbx/test/test_IlluminaData.py
+++ b/bcftbx/test/test_IlluminaData.py
@@ -2000,6 +2000,29 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(casava[0]['Recipe'],'')
         self.assertEqual(casava[0]['Operator'],'')
         self.assertEqual(casava[0]['SampleProject'],'PJB')
+    def test_handle_empty_trailing_lines(self):
+        """IEMSampleSheet: handle empty trailing lines
+
+        """
+        fp = io.StringIO(u"""[Header],,,,,,,,,,
+IEMFileVersion,4,,,,,,,,,
+Date,06/03/2014,,,,,,,,,
+,,,,,,,,,,
+[Data],,,,,,,,,,
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,PJB1-1579,PJB1-1579,,,N701,CGATGTAT ,N501,TCTTTCCC,PeterBriggs,
+1,PJB2-1580,PJB2-1580,,,N702,TGACCAAT ,N502,TCTTTCCC,PeterBriggs,
+,,,,,,,,,
+,,,,,,,,,,
+""")
+        iem = IEMSampleSheet(fp=fp)
+        self.assertEqual(len(iem.data),2)
+        self.assertEqual(
+            str(iem.data[0]),
+            "1,PJB1-1579,PJB1-1579,,,N701,CGATGTAT,N501,TCTTTCCC,PeterBriggs,")
+        self.assertEqual(
+            str(iem.data[1]),
+            "1,PJB2-1580,PJB2-1580,,,N702,TGACCAAT,N502,TCTTTCCC,PeterBriggs,")
     def test_bad_input_unrecognised_section(self):
         """IEMSampleSheet: raises exception for input with unrecognised section
 


### PR DESCRIPTION
PR that updates the `SampleSheet` class in `bcftbx/IlluminaData.py` to remove data from trailing empty lines after the `[Data]` section in an input sample sheet file.

Previously any empty lines would result in blank lines being stored in the `data` section of a `SampleSheet` instance, which could cause problems for sorting etc.