### PR TITLE
bcftbx/IlluminaData: extend data items exposed by 'IlluminaRunInfo' class

### DIFF
--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -187,7 +187,11 @@ class IlluminaRunInfo(object):
     Extracts basic information from a RunInfo.xml file:
 
     run_id     : the run id e.g.'130805_PJ600412T_0012_ABCDEZXDYY'
-    run_number : the run number e.g. '12'
+    run_number : the run number e.g. '0012'
+    instrument : the instrument name e.g. 'PJ600412T'
+    date       : the run date e.g. '130805'
+    flowcell   : the flowcell id e.g. 'ABCDEZXDYY'
+    lane_count : the flowcell lane count e.g. 8
     bases_mask : bases mask string derived from the read information
                  e.g. 'y101,I6,y101'
     reads      : a list of Python dictionaries (one per read)
@@ -212,13 +216,23 @@ class IlluminaRunInfo(object):
         self.runinfo_xml = runinfo_xml
         self.run_id = None
         self.run_number = None
+        self.instrument = None
+        self.flowcell = None
+        self.date = None
+        self.lane_count = None
         self.reads = []
         # Process contents
-        #
         doc = xml.dom.minidom.parse(self.runinfo_xml)
         run_tag = doc.getElementsByTagName('Run')[0]
         self.run_id = run_tag.getAttribute('Id')
         self.run_number = run_tag.getAttribute('Number')
+        self.instrument = \
+                doc.getElementsByTagName('Instrument')[0].firstChild.nodeValue
+        self.flowcell = \
+                doc.getElementsByTagName('Flowcell')[0].firstChild.nodeValue
+        self.date = doc.getElementsByTagName('Date')[0].firstChild.nodeValue
+        flowcell_layout_tag = doc.getElementsByTagName('FlowcellLayout')[0]
+        self.lane_count = flowcell_layout_tag.getAttribute('LaneCount')
         read_tags = doc.getElementsByTagName('Read')
         for read_tag in read_tags:
             self.reads.append({'number': read_tag.getAttribute('Number'),

--- a/bcftbx/test/test_IlluminaData.py
+++ b/bcftbx/test/test_IlluminaData.py
@@ -188,7 +188,11 @@ class TestIlluminaRunInfo(unittest.TestCase):
         run_info = IlluminaRunInfo(run_info_xml)
         self.assertEqual(run_info.run_id,
                          "151125_NB500968_0003_000000000-ABCDE1XX")
+        self.assertEqual(run_info.date,'151125')
+        self.assertEqual(run_info.instrument,'NB500968')
         self.assertEqual(run_info.run_number,'0003')
+        self.assertEqual(run_info.flowcell,'000000000-ABCDE1XX')
+        self.assertEqual(run_info.lane_count,'8')
         self.assertEqual(run_info.bases_mask,"y101,I8,I8,y101")
         self.assertEqual(len(run_info.reads),4)
         self.assertEqual(run_info.reads[0]['number'],'1')

--- a/bcftbx/test/test_IlluminaData.py
+++ b/bcftbx/test/test_IlluminaData.py
@@ -4,6 +4,7 @@
 from bcftbx.IlluminaData import *
 from bcftbx.mock import MockIlluminaRun
 from bcftbx.mock import MockIlluminaData
+from bcftbx.mock import RunInfoXml
 from bcftbx.TabFile import TabDataLine
 import bcftbx.utils
 import unittest
@@ -157,6 +158,51 @@ class TestIlluminaRun(unittest.TestCase):
         self.assertRaises(Exception,getattr,run,'bcl_extension')
         self.assertEqual(run.lanes,[])
         self.assertEqual(run.cycles,None)
+
+class TestIlluminaRunInfo(unittest.TestCase):
+    """
+    Tests for the IlluminaRunInfo class
+    """
+    def setUp(self):
+        # Create a temporary working directory
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        # Remove the test directory
+        try:
+            os.rmdir(self.tmpdir)
+        except Exception:
+            pass
+
+    def test_illuminaruninfo(self):
+        """
+        IlluminaRunInfo: check data is extracted
+        """
+        run_info_xml = os.path.join(self.tmpdir,"RunInfo.xml")
+        with open(run_info_xml,'wt') as fp:
+            fp.write(RunInfoXml.create(
+                run_name="151125_NB500968_0003_000000000-ABCDE1XX",
+                bases_mask="y101,I8,I8,y101",
+                nlanes=8,
+                tilecount=16))
+        run_info = IlluminaRunInfo(run_info_xml)
+        self.assertEqual(run_info.run_id,
+                         "151125_NB500968_0003_000000000-ABCDE1XX")
+        self.assertEqual(run_info.run_number,'0003')
+        self.assertEqual(run_info.bases_mask,"y101,I8,I8,y101")
+        self.assertEqual(len(run_info.reads),4)
+        self.assertEqual(run_info.reads[0]['number'],'1')
+        self.assertEqual(run_info.reads[0]['num_cycles'],'101')
+        self.assertEqual(run_info.reads[0]['is_indexed_read'],'N')
+        self.assertEqual(run_info.reads[1]['number'],'2')
+        self.assertEqual(run_info.reads[1]['num_cycles'],'8')
+        self.assertEqual(run_info.reads[1]['is_indexed_read'],'Y')
+        self.assertEqual(run_info.reads[2]['number'],'3')
+        self.assertEqual(run_info.reads[2]['num_cycles'],'8')
+        self.assertEqual(run_info.reads[2]['is_indexed_read'],'Y')
+        self.assertEqual(run_info.reads[3]['number'],'4')
+        self.assertEqual(run_info.reads[3]['num_cycles'],'101')
+        self.assertEqual(run_info.reads[3]['is_indexed_read'],'N')
 
 class BaseTestIlluminaData(unittest.TestCase):
     """


### PR DESCRIPTION
PR which extends the data items from the `RunInfo.xml` file which are exposed by the `IlluminaRunInfo` class (issue #164).

New attributes are:

* `instrument` (instrument ID, taken from the `<Instrument>` tag)
* `date` (run datestamp, taken from the `<Date>` tag)
* `flowcell` (flowcell ID, taken from the `<Flowcell>` tag)
* `lane_count` (flowcell lane count, taken from the `<FlowcellLayout LaneCount=... >` attribute)