### PR TITLE
bcftbx/TabFile: allow an optional 'fill' value to be specified when appending a new column

### DIFF
--- a/bcftbx/TabFile.py
+++ b/bcftbx/TabFile.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     TabFile.py: classes for reading and manipulating tab-delimited data
-#     Copyright (C) University of Manchester 2011-2019 Peter Briggs
+#     Copyright (C) University of Manchester 2011-2020 Peter Briggs
 #
 ########################################################################
 #

--- a/bcftbx/TabFile.py
+++ b/bcftbx/TabFile.py
@@ -744,14 +744,16 @@ class TabFile(object):
         self.__data.insert(i,data_line)
         return data_line
 
-    def appendColumn(self,name):
+    def appendColumn(self,name,fill_value=''):
         """Append a new (empty) column
 
         Arguments:
           name: name for the new column
+          fill_value: optional, value to insert into
+            all rows in the new column
         """
         for data in self.__data:
-            data.appendColumn(name,'')
+            data.appendColumn(name,fill_value)
         self.__header.append(name)
         self.__ncols = len(self.__header)
 

--- a/bcftbx/test/test_TabFile.py
+++ b/bcftbx/test/test_TabFile.py
@@ -236,6 +236,16 @@ chr2\t1234\t5678\t6.8
         self.assertEqual(tabfile.header()[4],'new')
         self.assertEqual(tabfile[0]['new'],'')
 
+    def test_append_column_with_value(self):
+        """Append new column to a Tabfile with a fill value
+        """
+        tabfile = TabFile('test',self.fp,first_line_is_header=True)
+        self.assertEqual(len(tabfile.header()),4)
+        tabfile.appendColumn('new',fill_value='new_value')
+        self.assertEqual(len(tabfile.header()),5)
+        self.assertEqual(tabfile.header()[4],'new')
+        self.assertEqual(tabfile[0]['new'],'new_value')
+
 class TestWhiteSpaceHandlingTabFile(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
PR which updates `TabFile.appendColumn()` to accept an optional 'fill value' to use when populating new column in each row.