### PR TITLE
bcftbx/mock: update mock 'RunInfoXml' to set the flowcell ID correctly

### DIFF
--- a/bcftbx/mock.py
+++ b/bcftbx/mock.py
@@ -137,6 +137,8 @@ class RunInfoXml(object):
             flowcell = items[3]
         except IndexError:
             flowcell = "XXXXABCD1"
+        if flowcell[0] in ('A','B',):
+            flowcell = flowcell[1:]
         # Bases mask
         reads = []
         for item in bases_mask.split(","):


### PR DESCRIPTION
PR which fixes an issue in the `RunInfoXml` class in `bcftbx/mock`, which is used to generate mock versions of the `RunInfo.xml` file from Illumina sequencer run directories.

Previously the flowcell ID extracted from the run name was not being set correctly in the XML file; this update fixes the issue.