### PR TITLE
bcftbx/TabFile: add functionality to 'TabFile' to handle commented lines

### DIFF
--- a/bcftbx/TabFile.py
+++ b/bcftbx/TabFile.py
@@ -508,7 +508,8 @@ class TabFile(object):
     def __init__(self,filen=None,fp=None,column_names=None,skip_first_line=False,
                  first_line_is_header=False,tab_data_line=TabDataLine,
                  delimiter='\t',convert=True,
-                 allow_underscores_in_numeric_literals=False):
+                 allow_underscores_in_numeric_literals=False,
+                 keep_commented_lines=False):
         """Create a new TabFile object
 
         If either of 'filen' or 'fp' arguments are given then the
@@ -539,6 +540,8 @@ class TabFile(object):
               then treat numerical values with underscores as
               numbers according to PEP 515; if False (the default)
               then treat them as strings
+          keep_commented_lines: (optional) if True then don't
+              remove commented lines
         """
         # Initialise
         self.__filen = filen
@@ -549,6 +552,7 @@ class TabFile(object):
         self.__convert = convert
         self.__allow_underscores_in_numbers = \
                     allow_underscores_in_numeric_literals
+        self.__keep_commented_lines = keep_commented_lines
         # Class to use for data lines
         self.__tabdataline = tab_data_line
         # Set up column names
@@ -595,7 +599,8 @@ class TabFile(object):
                 self.__setHeader(line.strip().strip('#').split(self.__delimiter))
                 first_line_is_header = False
                 continue
-            if line.lstrip().startswith('#'):
+            if line.lstrip().startswith('#') and \
+               not self.__keep_commented_lines:
                 # Skip commented line
                 continue
             # Store data

--- a/bcftbx/test/test_TabFile.py
+++ b/bcftbx/test/test_TabFile.py
@@ -520,6 +520,31 @@ chr1\t1_012\t4_292.6
         self.assertEqual(tabfile[0]['start'],"1_012")
         self.assertEqual(tabfile[0]['end'],"4_292.6")
 
+class TestHandleCommentsInTabFile(unittest.TestCase):
+    """Test handling commented lines
+    """
+    def test_remove_commented_lines_by_default(self):
+        """
+        TabFile: check commented lines are removed by default
+        """
+        fp = io.StringIO(
+u"""#chr\tstart\tend\tdata
+chr1\t1\t234\t1.2
+#chr1\t567\t890\t5.7\t4.6
+#chr2\t1234\t5678\t6.8
+chr2\t2345\t6789\t12.1
+""")
+        tabfile = TabFile(fp=fp,first_line_is_header=True)
+        self.assertEqual(len(tabfile),2)
+        self.assertEqual(tabfile[0]['chr'],"chr1")
+        self.assertEqual(tabfile[0]['start'],1)
+        self.assertEqual(tabfile[0]['end'],234)
+        self.assertEqual(tabfile[0]['data'],1.2)
+        self.assertEqual(tabfile[1]['chr'],"chr2")
+        self.assertEqual(tabfile[1]['start'],2345)
+        self.assertEqual(tabfile[1]['end'],6789)
+        self.assertEqual(tabfile[1]['data'],12.1)
+
 class TestBadTabFile(unittest.TestCase):
     """Test with 'bad' input files
     """

--- a/bcftbx/test/test_TabFile.py
+++ b/bcftbx/test/test_TabFile.py
@@ -527,13 +527,17 @@ class TestHandleCommentsInTabFile(unittest.TestCase):
         """
         TabFile: check commented lines are removed by default
         """
-        fp = io.StringIO(
+        content = \
 u"""#chr\tstart\tend\tdata
 chr1\t1\t234\t1.2
-#chr1\t567\t890\t5.7\t4.6
+#chr1\t567\t890\t5.7
 #chr2\t1234\t5678\t6.8
 chr2\t2345\t6789\t12.1
-""")
+"""
+        final = \
+u"""chr1\t1\t234\t1.2
+chr2\t2345\t6789\t12.1"""
+        fp = io.StringIO(content)
         tabfile = TabFile(fp=fp,first_line_is_header=True)
         self.assertEqual(len(tabfile),2)
         self.assertEqual(tabfile[0]['chr'],"chr1")
@@ -544,6 +548,46 @@ chr2\t2345\t6789\t12.1
         self.assertEqual(tabfile[1]['start'],2345)
         self.assertEqual(tabfile[1]['end'],6789)
         self.assertEqual(tabfile[1]['data'],12.1)
+        self.assertEqual(str(tabfile),final)
+
+    def test_keep_commented_lines(self):
+        """
+        TabFile: keep commented lines
+        """
+        content = \
+u"""#chr\tstart\tend\tdata
+chr1\t1\t234\t1.2
+#chr1\t567\t890\t5.7
+#chr2\t1234\t5678\t6.8
+chr2\t2345\t6789\t12.1
+"""
+        final = \
+u"""chr1\t1\t234\t1.2
+#chr1\t567\t890\t5.7
+#chr2\t1234\t5678\t6.8
+chr2\t2345\t6789\t12.1"""
+        fp = io.StringIO(content)
+        tabfile = TabFile(fp=fp,
+                          first_line_is_header=True,
+                          keep_commented_lines=True)
+        self.assertEqual(len(tabfile),4)
+        self.assertEqual(tabfile[0]['chr'],"chr1")
+        self.assertEqual(tabfile[0]['start'],1)
+        self.assertEqual(tabfile[0]['end'],234)
+        self.assertEqual(tabfile[0]['data'],1.2)
+        self.assertEqual(tabfile[1]['chr'],"#chr1")
+        self.assertEqual(tabfile[1]['start'],567)
+        self.assertEqual(tabfile[1]['end'],890)
+        self.assertEqual(tabfile[1]['data'],5.7)
+        self.assertEqual(tabfile[2]['chr'],"#chr2")
+        self.assertEqual(tabfile[2]['start'],1234)
+        self.assertEqual(tabfile[2]['end'],5678)
+        self.assertEqual(tabfile[2]['data'],6.8)
+        self.assertEqual(tabfile[3]['chr'],"chr2")
+        self.assertEqual(tabfile[3]['start'],2345)
+        self.assertEqual(tabfile[3]['end'],6789)
+        self.assertEqual(tabfile[3]['data'],12.1)
+        self.assertEqual(str(tabfile),final)
 
 class TestBadTabFile(unittest.TestCase):
     """Test with 'bad' input files


### PR DESCRIPTION
PR which extends the `TabFile` class in `bcftbx/TabFile` so that it will keep commented lines (i.e. lines starting with a `#` symbol); by default these lines are ignored on loading the data. When commented lines are preserved then leading `#` symbols become part of the data item in the first column of the file.