### PR TITLE
verify_paired.py: fix broken '--version' CLI option

### DIFF
--- a/illumina2cluster/verify_paired.py
+++ b/illumina2cluster/verify_paired.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     verify_paired.py: check R1 and R2 fastq files are consistent
-#     Copyright (C) University of Manchester 2013,2019 Peter Briggs
+#     Copyright (C) University of Manchester 2013-2021 Peter Briggs
 #
 ########################################################################
 #
@@ -16,7 +16,7 @@ the files form an R1/2 pair.
 
 """
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 #######################################################################
 # Import modules that this module depends on
@@ -44,9 +44,10 @@ if __name__ == "__main__":
     
     # Create command line parser
     p = argparse.ArgumentParser(
-        version="%(prog)s "+__version__,
         description="Check that read headers for R1 and R2 fastq files "
         "are in agreement, and that the files form an R1/2 pair.")
+    p.add_argument('--version',action='version',
+                   version="%(prog)s "+__version__)
     p.add_argument('fastq_file_r1',metavar="R1.fastq",
                    help="Fastq file with R1 reads")
     p.add_argument('fastq_file_r2',metavar="R2.fastq",


### PR DESCRIPTION
PR which fixes the broken `--version` option of the `verify_paired.py` utility, which affects Python 3.6.