### PR TITLE
Update Sphinx documentation generation to use the 'napoleon' extension

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,9 @@ sys.path.append('../')
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc']
+extensions = ['sphinx.ext.autodoc',
+              'sphinx.ext.napoleon',
+              'sphinx.ext.intersphinx',]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
PR which updates the documentation generation via Sphinx, to use the `napoleon` extension to handle "Google-style" class and function docstrings:

https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html