### PR TITLE
setup.py: remove attempt to install scripts from defunct 'utils' dir

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,6 @@ from glob import glob
 scripts = []
 for pattern in ('bin/*.py','bin/*.sh',):
     scripts.extend(glob(pattern))
-for pattern in ('utils/*.pl','utils/*.py','utils/*.R','utils/*.sh'):
-    scripts.extend(glob(pattern))
 
 # Setup for installation etc
 from setuptools import setup


### PR DESCRIPTION
PR which tidies up after PR #198, by removing the code that attempts to collect scripts and utilities for installation from the now-defunct `utils` subdirectory.