### PR TITLE
Add NovaSeq 6000 as recognised sequencing platform

### DIFF
--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -1,5 +1,5 @@
 #     IlluminaData.py: module for handling data about Illumina sequencer runs
-#     Copyright (C) University of Manchester 2012-2021 Peter Briggs
+#     Copyright (C) University of Manchester 2012-2022 Peter Briggs
 #
 ########################################################################
 #
@@ -40,6 +40,7 @@ KNOWN_PLATFORMS = ('illumina-ga2x',
                    'hiseq4000',
                    'miseq',
                    'nextseq',
+                   'novaseq6000',
                    'miniseq',
                    'iseq')
 

--- a/bcftbx/platforms.py
+++ b/bcftbx/platforms.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     platforms.py: utilities and data to identify sequencer platforms
-#     Copyright (C) University of Manchester 2013-2018 Peter Briggs
+#     Copyright (C) University of Manchester 2013-2022 Peter Briggs
 #
 ########################################################################
 #
@@ -26,6 +26,7 @@ PLATFORMS['hiseq'] = "Illumina HISeq"
 PLATFORMS['miseq'] = "Illumina MISeq"
 PLATFORMS['miniseq'] = "MiniSeq"
 PLATFORMS['nextseq'] = "Illumina NextSeq"
+PLATFORMS['novaseq6000'] = "NovaSeq 6000"
 PLATFORMS['iseq'] = "Illumina iSeq"
 PLATFORMS['illumina'] = "Unknown/Illumina"
 PLATFORMS['other'] = "Unknown/external"


### PR DESCRIPTION
PR which updates the `bcftbx` library code to add `novaseq6000` (for Illumina's NovaSeq 6000 instrument) as a recognised sequencer platform.