### PR TITLE
bcftbx/IlluminaData: fix bug in IlluminaData class for mixed lane/no lane Fastqs

### DIFF
--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -411,7 +411,8 @@ class IlluminaData:
                     lane = IlluminaFastq(fq).lane_number
                     if lane not in self.lanes:
                         self.lanes.append(lane)
-        self.lanes = sorted(self.lanes)
+        self.lanes = sorted([l for l in self.lanes
+                             if l is not None or len(self.lanes) == 1])
 
     def _populate_casava_style(self):
         """


### PR DESCRIPTION
Fixes a bug in the `IlluminaData` class (in `bcftbx/IlluminaData.py`) for `bcl2fastq2`-style outputs, when "mixed" Fastq names are found where some have lane numbers and others don't.

This situation can occur if the `bcl2fastq`-style output directory has actually been assembled from multiple runs of Fastq generation software where some projects have had e.g. `--no-lane-splitting` specified and others haven't.

In these cases the bug manifested itself as an error trying to sort the collected lane numbers (which had been acquired from the Fastq file names) (as the non-lane-split Fastqs return the lane as `None`). The fix is to remove the `None` lane designation from the list whenever such a mixture is encountered.