### PR TITLE
Update Github Python CI workflow to fix missing Python 3.6

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -8,7 +8,9 @@ on: [ push, pull_request ]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    # Switched from ubuntu-latest to ubuntu-20.04 as former
+    # doesn't support Python 3.6
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Update the Github Python CI workflow to explicitly use ubuntu-20.04 (rather than ubuntu-latest), in order to fix errors with Python 3.6 tests (since Python 3.6 is EOL and not supported by ubuntu-22.04 - see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877).