### PR TITLE
bcftbx/IlluminaData: fix bug in IlluminaProject assigning undetermined Fastqs

### DIFF
--- a/bcftbx/IlluminaData.py
+++ b/bcftbx/IlluminaData.py
@@ -655,13 +655,15 @@ class IlluminaProject:
                                                        leading_dir[0])
                 else:
                     # Handle 'undetermined' data
-                    try:
-                        fqs = [f for f in fastqs
-                               if "lane%d" % IlluminaFastq(f).lane_number
-                               == sample_name]
-                    except TypeError:
-                        # No lane, take all fastqs
-                        fqs = [fq for fq in fastqs]
+                    # Try Fastqs with matching lane
+                    fqs = [fq for fq in fastqs
+                           if IlluminaFastq(fq).lane_number is not None and
+                           "lane%d" % IlluminaFastq(fq).lane_number
+                           == sample_name]
+                    if not fqs:
+                        # No lane, take all fastqs without a lane
+                        fqs = [fq for fq in fastqs
+                               if IlluminaFastq(fq).lane_number is None]
                 self.samples.append(IlluminaSample(sample_dirn,
                                                    fastqs=fqs,
                                                    name=sample_name,


### PR DESCRIPTION
Fix a bug in the `IlluminaProject` class of `bcftbx/IlluminaData`, where Fastqs are "double assigned" for `undetermined` when a mixture of Fastq names with and without lanes is encountered.

The bug manifested as the Fastqs without lanes being assigned twice, to their own "sample" and also appended to the "laned samples". The update ensures that each undetermined Fastq is only assigned to a single "sample".