### PR TITLE
bcftbx/Md5sum: reimplement 'md5sum' function to reduce memory footprint

### DIFF
--- a/bcftbx/Md5sum.py
+++ b/bcftbx/Md5sum.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     Md5sum.py: classes and functions for md5 checksum operations
-#     Copyright (C) University of Manchester 2012-2020 Peter Briggs
+#     Copyright (C) University of Manchester 2012-2022 Peter Briggs
 #
 ########################################################################
 #
@@ -471,20 +471,19 @@ def md5sum(f):
         
     Returns:
       Md5sum digest for the named file.
-
     """
     chksum = hashlib.md5()
     close_fp = False
     try:
-        fp = io.open(f,"rb",buffering=BLOCKSIZE)
+        fp = open(f,"rb")
         close_fp = True
     except TypeError:
         fp = f
-    for block in iter(fp.read,''):
-        if block:
-            chksum.update(block)
-        else:
+    while True:
+        buf = fp.read(BLOCKSIZE)
+        if not buf:
             break
+        chksum.update(buf)
     if close_fp:
         fp.close()
     return chksum.hexdigest()


### PR DESCRIPTION
Reimplements the `md5sum` function to reduce the memory footprint when operating on large files, based on the Stack Overflow answer at https://stackoverflow.com/a/1131255/579925 (responding to the question "[Get the MD5 hash of big files in Python](https://stackoverflow.com/questions/1131220/get-the-md5-hash-of-big-files-in-python)"). The original implementation would run out of memory for large files.