### PR TITLE
bcftbx/utils: new function 'convert_size_to_bytes'

### DIFF
--- a/bcftbx/test/test_utils.py
+++ b/bcftbx/test/test_utils.py
@@ -801,6 +801,20 @@ class TestFormatFileSize(unittest.TestCase):
         self.assertEqual("0.0T",format_file_size(195035136,units='T'))
         self.assertEqual("0.2T",format_file_size(171798691900,units='T'))
 
+class TestConvertSizeToBytes(unittest.TestCase):
+    """
+    Unit tests for converting file sizes to bytes
+    """
+    def test_convert_size_to_bytes(self):
+        """
+        convert_size_to_bytes: handle different inputs
+        """
+        self.assertEqual(convert_size_to_bytes('4.0K'),4096)
+        self.assertEqual(convert_size_to_bytes('4.0M'),4194304)
+        self.assertEqual(convert_size_to_bytes('4.0G'),4294967296)
+        self.assertEqual(convert_size_to_bytes('4.0T'),4398046511104)
+        self.assertEqual(convert_size_to_bytes('4T'),4398046511104)
+
 class ExampleDirLinks(ExampleDirSpiders):
     """Extended example dir for testing symbolic link handling
 

--- a/bcftbx/utils.py
+++ b/bcftbx/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     utils.py: utility classes and functions shared between BCF codes
-#     Copyright (C) University of Manchester 2013-2020 Peter Briggs
+#     Copyright (C) University of Manchester 2013-2023 Peter Briggs
 #
 ########################################################################
 #
@@ -31,6 +31,7 @@ File system wrappers and utilities:
   chmod
   touch
   format_file_size
+  convert_size_to_bytes
   commonprefix
   is_gzipped_file
   rootname
@@ -91,6 +92,7 @@ import grp
 import datetime
 import re
 import socket
+import math
 from builtins import range
 
 #######################################################################
@@ -716,7 +718,28 @@ def format_file_size(fsize,units=None):
             else:
                 break
     return "%.1f%s" % (fsize,unit)
-            
+
+def convert_size_to_bytes(size):
+    """
+    Converts a human-readable size specification to bytes
+
+    Given an arbitary human-readable file size (e.g.
+    '4.0K', '186M', '1.5G'), returns the equivalent size
+    in bytes.
+
+    Arguments:
+      size (str): size specification string
+
+    Returns:
+      Integer: size expressed as number of bytes.
+    """
+    try:
+        return int(str(size))
+    except ValueError:
+        units = str(size)[-1].upper()
+        p = "KMGTP".index(units) + 1
+        return int(float(str(size)[:-1])) * int(math.pow(1024,p))
+
 def commonprefix(path1,path2):
     """Determine common prefix path for path1 and path2
 


### PR DESCRIPTION
Add a new function `convert_size_to_bytes` in the `bcftbx/utils` module, to convert human-readable string representations of file sizes (e.g. `20M`, `1.5T` etc) to the equivalent size in bytes (essentially the reverse of the existing `format_file_size` function).