### PR TITLE
genomics-bcftbx version 1.13.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,25 @@ Version History and Changes
 ===========================
 
 ---------------------------
+Version 1.13.0 (2023-17-10)
+---------------------------
+
+* bcftbx/utils: new function 'convert_size_to_bytes'
+  https://github.com/fls-bioinformatics-core/genomics/pull/213
+* bcftbx/mock: 'MockIlluminaRun' updated to add 'miniseq' as
+  a platform, expose flow cell mode, and create additional files
+  (including run completion indicators) in mock run directories
+  https://github.com/fls-bioinformatics-core/genomics/pull/212
+* bcftbx/md5sum: reimplement 'md5sum' function to reduce
+  memory footprint
+  https://github.com/fls-bioinformatics-core/genomics/pull/211
+* bcftbx/IlluminData: fix bugs in 'IlluminaProject' when
+  assigning Fastqs when there is a mixture of lanes and no-lanes
+  in Fastq names
+  https://github.com/fls-bioinformatics-core/genomics/pull/210
+  https://github.com/fls-bioinformatics-core/genomics/pull/208
+
+---------------------------
 Version 1.12.0 (2022-12-06)
 ---------------------------
 

--- a/bcftbx/__init__.py
+++ b/bcftbx/__init__.py
@@ -1,5 +1,5 @@
 # Current version of the bcftbx package
-__version__ = '1.12.0'
+__version__ = '1.13.0'
 
 def get_version():
     """Returns a string with the current version of the bcftbx package (e.g., "0.2.0")


### PR DESCRIPTION
New version 1.13.0 to update stable version with all changes since previous release (1.12.0) - see CHANGELOG for summary.