### PR TITLE
genomics-bcftbx version 1.13.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@ Version History and Changes
 ===========================
 
 ---------------------------
+Version 1.13.1 (2023-12-19)
+---------------------------
+
+* bcftbx/mock: bug fixed with invalid default bases mask being
+  supplied for 'novaseq' platform in the 'MockIlluminaRun' class
+  https://github.com/fls-bioinformatics-core/genomics/pull/215
+
+---------------------------
 Version 1.13.0 (2023-17-10)
 ---------------------------
 

--- a/bcftbx/__init__.py
+++ b/bcftbx/__init__.py
@@ -1,5 +1,5 @@
 # Current version of the bcftbx package
-__version__ = '1.13.0'
+__version__ = '1.13.1'
 
 def get_version():
     """Returns a string with the current version of the bcftbx package (e.g., "0.2.0")


### PR DESCRIPTION
Patch release 1.13.1 to update stable version with bug fixes in previous release (1.13.0) - see CHANGELOG for summary.