### PR TITLE
bcftbx: refactor 'platforms' module into subpackage

### DIFF
--- a/bcftbx/platforms/__init__.py
+++ b/bcftbx/platforms/__init__.py
@@ -1,18 +1,16 @@
 #!/usr/bin/env python
 #
 #     platforms.py: utilities and data to identify sequencer platforms
-#     Copyright (C) University of Manchester 2013-2022 Peter Briggs
+#     Copyright (C) University of Manchester 2013-2024 Peter Briggs
 #
 ########################################################################
 #
-# platforms.py
+# platforms
 #
 #########################################################################
 
-"""platforms.py
-
+"""
 Utilities and data to identify NGS sequencer platforms
-
 """
 
 # Dictionary of sequencer platforms

--- a/bcftbx/platforms/__init__.py
+++ b/bcftbx/platforms/__init__.py
@@ -16,7 +16,7 @@ Utilities and data to identify NGS sequencer platforms
 """
 
 # Dictionary of sequencer platforms
-from .utils import OrderedDictionary
+from ..utils import OrderedDictionary
 PLATFORMS = OrderedDictionary()
 PLATFORMS['solid4'] = "SOLiD 4"
 PLATFORMS['solid5500'] = "SOLiD 5500"

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(name = "genomics-bcftbx",
       maintainer_email = 'peter.briggs@manchester.ac.uk',
       packages = ['bcftbx',
                   'bcftbx.cli',
+                  'bcftbx.platforms',
                   'bcftbx.qc'],
       license = 'AFL-3',
       # Pull in dependencies


### PR DESCRIPTION
Refactors the `platforms` module into a subpackage within `bcftbx`, i.e.

    platforms.py -> platforms/__init__.py

This shouldn't affect how the module and its members are imported, but it will make it easier to start refactoring the library to create further modules or packages within the `platforms` subpackage for specific sequencing platforms (as part of an anticipated reorganisation of the library).