### PR TITLE
Ensure GEJobRunner can handle '-pe amd.pe' when collecting NSLOTS

### DIFF
--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -518,8 +518,8 @@ class GEJobRunner(BaseJobRunner):
 
         This is extracted from the 'ge_extra_args'
         property, by looking for qsub options of the
-        form '-pe smp.pe N' (in which case 'nslots'
-        will be N).
+        form '-pe XXXX N' (e.g. '-pe smp.pe 8'), where
+        'nslots' will be N.
         """
         nslots = 1
         if self.ge_extra_args is not None:

--- a/bcftbx/test/test_JobRunner.py
+++ b/bcftbx/test/test_JobRunner.py
@@ -509,7 +509,7 @@ class TestGEJobRunner(unittest.TestCase):
         self.assertEqual(runner.queue(jobid),"mock.q")
 
     def test_ge_job_runner_nslots(self):
-        """Test GEJobRunner sets BCFTBX_RUNNER_NSLOTS
+        """Test GEJobRunner sets BCFTBX_RUNNER_NSLOTS (-pe smp.pe)
         """
         # Create a runner and check default nslots
         runner = GEJobRunner()
@@ -524,6 +524,32 @@ class TestGEJobRunner(unittest.TestCase):
             self.assertEqual(u"1\n",fp.read())
         # Create a runner with multiple nslots
         runner = GEJobRunner(ge_extra_args=['-pe','smp.pe','8'])
+        self.assertEqual(runner.nslots,8)
+        jobid = self.run_job(runner,
+                             'test',
+                             self.working_dir,
+                             '/bin/bash',
+                             ('-c','echo $BCFTBX_RUNNER_NSLOTS',))
+        self.wait_for_jobs(runner,jobid)
+        with io.open(runner.logFile(jobid),'rt') as fp:
+            self.assertEqual(u"8\n",fp.read())
+
+    def test_ge_job_runner_nslots_amd_pe(self):
+        """Test GEJobRunner sets BCFTBX_RUNNER_NSLOTS (-pe amd.pe)
+        """
+        # Create a runner and check default nslots
+        runner = GEJobRunner()
+        self.assertEqual(runner.nslots,1)
+        jobid = self.run_job(runner,
+                             'test',
+                             self.working_dir,
+                             '/bin/bash',
+                             ('-c','echo $BCFTBX_RUNNER_NSLOTS',))
+        self.wait_for_jobs(runner,jobid)
+        with io.open(runner.logFile(jobid),'rt') as fp:
+            self.assertEqual(u"1\n",fp.read())
+        # Create a runner with multiple nslots
+        runner = GEJobRunner(ge_extra_args=['-pe','amd.pe','8'])
         self.assertEqual(runner.nslots,8)
         jobid = self.run_job(runner,
                              'test',


### PR DESCRIPTION
Add test for `GEJobRunner` class in `bcftbx/JobRunner` module to ensure that it can handle `-pe amd.pe` as well as `-pe smp.pe` when collecting the number of cores (aka `NSLOTS`).

The functionality was already present but this test makes it explicit (along with an update to the docstring for the `nslots` method of `GEJobRunner`).