### PR TITLE
WIP implement job runner for Slurm

### DIFF
--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -1498,7 +1498,7 @@ exit $exit_code
         state', False otherwise.
         """
         # FIXME don't know how to detect error state for Slurm job
-        logging.warning("SlurmRunner: 'errorState' method not implemented")
+        logging.debug("SlurmRunner: 'errorState' method not implemented")
         return False
 
     def list(self):

--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     JobRunner.py: classes for starting and managing job runs
-#     Copyright (C) University of Manchester 2011-2020 Peter Briggs
+#     Copyright (C) University of Manchester 2011-2025 Peter Briggs
 #
 ########################################################################
 #
@@ -17,6 +17,7 @@ by subclasses. The subclasses implemented here are:
 
 * SimpleJobRunner: run jobs (e.g. scripts) on a local file system.
 * GEJobRunner    : run jobs using Grid Engine (GE) i.e. qsub, qdel etc
+* SlurmRunner    : run jobs using Slurm i.e. sbatch, scancel etc
 
 A single JobRunner instance can be used to start and manage multiple processes.
 
@@ -44,10 +45,10 @@ is created and executed.
 
 Additionally runners set an 'BCFTBX_RUNNER_NSLOTS' environment variable,
 which is set to the number of slots (aka CPUs/cores/threads) available to
-processes executed by the runner. For both 'SimpleJobRunner' and
-'GEJobRunner', this defaults to one (i.e. serial jobs); the 'nslots'
-option can be used when instantiating 'SimpleJobRunner' objects to
-specify more cores, for example:
+processes executed by the runner. For all runners this defaults to one
+(i.e. serial jobs); the 'nslots' option can be used when instantiating
+'SimpleJobRunner' and 'SlurmRunner' objects to specify more cores, for
+example:
 
 >>> multicore_runner = SimpleJobRunner(nslots=4)
 
@@ -1158,6 +1159,738 @@ exit $exit_code
             # prepend an underscore
             ge_name = "_%s" % ge_name
         return ge_name
+
+class SlurmRunner(BaseJobRunner):
+    """
+    Class implementing job runner for Slurm
+
+    SlurmRunner submits jobs to a Slurm cluster using the 'sbatch'
+    command, determines the status of jobs using 'squeue', and
+    and terminates them using 'scancel'.
+
+    Additionally the runner can be configured to target a specific
+    partition and number of cores on initialisation.
+
+    Each SlurmRunner instance creates a temporary directory which
+    it uses for internal admin; this will be removed at program
+    exit via 'atexit'.
+
+    Arguments:
+      log_dir (str): path of directory to write log files to (set to 'None'
+        to use cwd)
+      nslots (int): number of threads assigned to the runner instance
+      partition (str): name of Slurm partition to target (set to 'None'
+        to use default queue)
+      join_logs (bool): if True then combine stderr and stdout into a
+        single log file (default is to write stdout and stderr to separate
+        log files)
+      slurm_extra_args (list): arbitrary additional arguments to supply
+        to 'sbatch' (e.g. '["-n", 8]')
+      poll_interval (int): time interval to use when polling Slurm using
+        'squeue' etc (default 5s)
+      timeout (int): maximum length of time to wait before giving up when
+        polling Slurm (default 30s)
+    """
+
+    def __init__(self, log_dir=None, nslots=None, partition=None,
+                 join_logs=None, slurm_extra_args=None, poll_interval=5.0,
+                 timeout=30.0):
+        # Internal parameters
+        self._name = "SlurmRunner"
+        self._admin_dir = None
+        self._job_count = 0
+        self._shell = "/bin/bash"
+        # Directory for log files
+        self.set_log_dir(log_dir)
+        # Keep track of data (names, log dirs etc) for each job
+        self._job_number = {}
+        self._names = {}
+        self._log_dirs = {}
+        self._error_state = {}
+        self._exit_status = {}
+        self._finalizing = {}
+        self._queue = {}
+        self._start_time = {}
+        # Job id lock
+        self._job_lock = ResourceLock()
+        # Job grace period lock
+        self._updating_grace_period = ResourceLock()
+        # Job submission lock
+        self._submit_lock = ResourceLock()
+        # Cached job list
+        self._cached_job_list_lifetime = 2.0
+        self._cached_job_list_timestamp = 0.0
+        self._cached_job_list = []
+        self._cached_job_list_force_update = True
+        # Cached qstat output
+        self._cached_squeue_output_lifetime = 2.0
+        self._cached_squeue_output_timestamp = 0.0
+        self._cached_squeue_output = None
+        # Grace period for new jobs
+        self._new_job_grace_period = 2.0
+        # Polling intervals and timeout periods (seconds)
+        self._poll_interval = int(poll_interval)
+        self._timeout = int(timeout)
+        # Register clean up function
+        atexit.register(self._clean_up_admin_dir)
+        # Slurm-specific variables
+        self._join_logs = join_logs
+        self._nslots = nslots
+        self._partition = partition
+        if slurm_extra_args is not None:
+            self._slurm_extra_args = [str(x) for x in slurm_extra_args]
+        else:
+            self._slurm_extra_args = None
+        # FIXME clean up extra arguments to remove -n, -p etc?
+        self._check_slurm_extra_args()
+        # Create admin dir
+        self._make_admin_dir()
+
+    def __repr__(self):
+        args = []
+        if self._nslots:
+            args.append(f"nslots={self.nslots}")
+        if self._partition:
+            args.append(f"partition={self._partition}")
+        if self._join_logs:
+            args.append(f"join_logs={self.join_logs}")
+        if self._slurm_extra_args:
+            args.append(f"slurm_args={' '.join(self.slurm_extra_args)}")
+        if args:
+            return self._name + f"({','.join(args)})"
+        else:
+            return self._name
+
+    def name(self, job_id):
+        """
+        Return the name for a specific job
+
+        Arguments:
+          job_id (int): Job ID to get the name for
+        """
+        return self._names[job_id]
+
+    @property
+    def nslots(self):
+        """
+        Return the number of associated slots
+
+        If not set then defaults to 1.
+        """
+        if self._nslots is None:
+            return 1
+        else:
+            return int(self._nslots)
+
+    @property
+    def partition(self):
+        """
+        Return the assigned partition
+
+        If not set then defaults to 1.
+        """
+        return self._partition
+
+    @property
+    def join_logs(self):
+        """
+        Return flag for whether to combine stdout and stderr logs
+
+        If not set then defaults to 'False'.
+        """
+        if self._join_logs is None:
+            return False
+        else:
+            return bool(self._join_logs)
+
+    @property
+    def slurm_extra_args(self):
+        """
+        Return the extra Slurm arguments
+        """
+        if self._slurm_extra_args:
+            return [x for x in self._slurm_extra_args]
+        else:
+            return None
+
+    def run(self, name, working_dir, script, args):
+        """
+        Submit a script or command to the cluster via 'sbatch'
+
+        Arguments:
+          name (str): name to give the job
+          working_dir (str): path to directory to run the job in
+          script (str): path to command or script file to run
+          args (list): list of arguments to supply to the script
+
+        Returns:
+          Job id for submitted job, or 'None' if job failed to
+          start.
+        """
+        logging.debug(f"{self._name:11}: submitting job")
+        logging.debug(f"Name       : {name}")
+        logging.debug(f"Nslots     : {self.nslots}")
+        logging.debug(f"Partition  : {self.partition}")
+        logging.debug(f"Join logs  : {self.join_logs}")
+        logging.debug(f"Extra args : {self.slurm_extra_args}")
+        logging.debug(f"Log dir    : {self.log_dir}")
+        logging.debug(f"Working_dir: {working_dir}")
+        logging.debug(f"Script     : {script}")
+        logging.debug(f"Arguments  : {str(args)}")
+        # Wait for lock on job submission
+        start_time = time.time()
+        submit_lock = None
+        while submit_lock is None:
+            submit_lock = self._submit_lock.acquire("job_submission",
+                                                    timeout=self._timeout)
+        # Get internal job number
+        self._job_count += 1
+        job_number = self._job_count
+        logging.debug("Internal job count: %s" % job_number)
+        # Release the lock
+        self._submit_lock.release(submit_lock)
+        # Build script to run the command to be submitted
+        job_dir = os.path.join(self._admin_dir, str(job_number))
+        logging.debug("Job admin dir     : %s" % job_dir)
+        os.mkdir(job_dir)
+        cmd_args = [script]
+        for arg in args:
+            # Quote arguments containing whitespace
+            if arg.count(' ') or arg.count('\t'):
+                arg = "\"%s\"" % arg
+            cmd_args.append(arg)
+        cmd = ' '.join(cmd_args)
+        job_script = os.path.join(job_dir, "job_script.sh")
+        with open(job_script, "wt") as fp:
+            fp.write(u"""#!{shell}
+export BCFTBX_RUNNER_NSLOTS=$SLURM_NTASKS
+echo "$BCFTBX_RUNNER_NSLOTS" > {job_dir}/__jobrunner_nslots
+{cmd}
+exit_code=$?
+echo "$exit_code" > {job_dir}/__exit_code.tmp
+mv {job_dir}/__exit_code.tmp {job_dir}/__exit_code
+exit $exit_code
+""".format(shell=self._shell, job_dir=job_dir, cmd=cmd))
+        os.chmod(job_script,0o755)
+        job_name = self._sanitize_job_name(name)
+        logging.debug("Slurm job name: %s" % job_name)
+        # Log file (replicate Grid Engine)
+        stdout = "%x.o%j"
+        if self.log_dir:
+            stdout = os.path.join(self.log_dir, stdout)
+        if self.join_logs:
+            stderr = None
+        else:
+            stderr = "%x.e%j"
+            if self.log_dir:
+                stderr = os.path.join(self.log_dir, stderr)
+        # Build sbatch command to submit script
+        sbatch = ["sbatch",
+                  "--export=ALL",
+                  "-J", job_name,
+                  "-n", str(self.nslots)]
+        if self._partition:
+            sbatch.extend(["-p", self._partition])
+        sbatch.extend(["-o", stdout])
+        if stderr:
+            sbatch.extend(["-e", stderr])
+        if working_dir:
+            sbatch.extend(('--chdir',working_dir))
+        if self.slurm_extra_args:
+            sbatch.extend(self.slurm_extra_args)
+        sbatch.append(job_script)
+        logging.debug("SlurmRunner: sbatch command: %s" % sbatch)
+        # Run the sbatch job in the current directory
+        cwd = os.getcwd()
+        if not os.path.exists(cwd):
+            logging.error("SlurmRunner: cwd doesn't exist!")
+            return None
+        logging.debug("SlurmRunner: executing in %s" % cwd)
+        p = subprocess.Popen(sbatch, cwd=cwd,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE,
+                             universal_newlines=True)
+        stdoutdata, stderrdata = p.communicate()
+        logging.debug(f"SlurmRunner: sbatch output: {stdoutdata}")
+        logging.debug(f"SlurmRunner: sbatch error: {stderrdata}")
+        # Check stderr to try and detect error with submission
+        error = stderrdata.strip()
+        if error:
+            # Just echo error message as a warning
+            logging.warning("SlurmRunner: '%s'" % error)
+        # Capture the job id from the output
+        job_id = None
+        for line in stdoutdata.split('\n'):
+            if line.startswith("Submitted batch job"):
+                job_id = line.split()[-1]
+        if job_id is None:
+            logging.error("SlurmRunner: failed to get job ID from "
+                          "sbatch output: %r" % stdoutdata)
+        logging.debug(f"SlurmRunner: done - job id = {job_id}")
+        # Store internal number, name and log dir against job id
+        if job_id is not None:
+            self._job_number[job_id] = job_number
+            self._names[job_id] = name
+            if self.log_dir is None:
+                self._log_dirs[job_id] = working_dir
+            else:
+                self._log_dirs[job_id] = self.log_dir
+            self._start_time[job_id] = time.time()
+        # Force refresh of job list
+        self._cached_job_list_force_update = True
+        # Return the job id
+        return job_id
+
+    def terminate(self, job_id):
+        """
+        Remove a job from the Slurm queue using 'scancel'
+        """
+        logging.debug("SlurmRunner: deleting job")
+        scancel=("scancel", job_id)
+        p = subprocess.Popen(scancel, stdout=subprocess.PIPE)
+        stdoutdata, stderrdata = p.communicate()
+        message = stdoutdata.strip()
+        logging.debug("Slurmrunner: scancel: %s" % message)
+        if job_id in self._start_time:
+            del(self._start_time[job_id])
+        # Write an exit code file for the job
+        exit_code_file = os.path.join(self._admin_dir,
+                                      str(self._job_number[job_id]),
+                                      "__exit_code")
+        with open("%s.tmp" % exit_code_file, "wt") as fp:
+            fp.write("-1\n")
+        os.rename("%s.tmp" % exit_code_file, exit_code_file)
+        # Force update of cached job list
+        self._cached_job_list_force_update = True
+        return True
+
+    def logFile(self, job_id):
+        """
+        Return the log file name for a job
+
+        The name should be '<name>.o<job_id>'
+        """
+        name = self._names[job_id]
+        log_file = "%s.o%s" % (name, job_id)
+        if self._log_dirs[job_id] is not None:
+            log_file = os.path.join(self._log_dirs[job_id], log_file)
+        return log_file
+
+    def errFile(self, job_id):
+        """
+        Return the error file name for a job
+
+        The name should be '<name>.e<job_id>'
+        """
+        if self.join_logs:
+            return self.logFile(job_id)
+        name = self._names[job_id]
+        err_file = "%s.e%s" % (name,job_id)
+        if self._log_dirs[job_id] is not None:
+            err_file = os.path.join(self._log_dirs[job_id], err_file)
+        return err_file
+
+    def errorState(self,job_id):
+        """
+        Check if the job is in an error state
+
+        Return True if the job is deemed to be in an 'error
+        state', False otherwise.
+        """
+        # FIXME don't know how to detect error state for Slurm job
+        logging.warning("SlurmRunner: 'errorState' method not implemented")
+        return False
+
+    def list(self):
+        """
+        Get list of job ids which are queued or running
+        """
+        # Check cached job list
+        use_cache = (not self._cached_job_list_force_update and
+                     (time.time() - self._cached_job_list_timestamp) <
+                     self._cached_job_list_lifetime)
+        if use_cache:
+            logging.debug("SlurmRunner: using cached job list")
+            job_ids = self._cached_job_list
+            # Add the jobs in grace period
+            grace_period_jobs = list(self._start_time.keys())
+            for job_id in grace_period_jobs:
+                if job_id not in job_ids:
+                    job_ids.append(job_id)
+            return job_ids
+        else:
+            logging.debug("SlurmRunner: building job list")
+        # Update jobs in grace period
+        for job_id in list(self._start_time.keys()):
+            self._update_job_in_grace_period(job_id)
+        grace_period_jobs = list(self._start_time.keys())
+        # Build initial list from directory contents
+        job_ids = []
+        for job_id in list(self._job_number.keys()):
+            logging.debug(f"SlurmRunner: -- checking job {job_id}")
+            try:
+                job_number = self._job_number[job_id]
+            except KeyError:
+                # Job has been removed since the list was
+                # fetched? Ignore
+                continue
+            job_dir = os.path.join(self._admin_dir, str(job_number))
+            if os.path.exists(job_dir):
+                # Job dir exists
+                logging.debug("SlurmRunner: -- found %s" % job_dir)
+                exit_code_file = os.path.join(job_dir, "__exit_code")
+                if os.path.exists(exit_code_file):
+                    # Job has finished, handle completion
+                    logging.debug("SlurmRunner: -- exit code file exists, "
+                                  f"completing job {job_id}")
+                    self._handle_job_completion(job_id)
+                else:
+                    # Job still running
+                    logging.debug("SlurmRunner: -- no exit code file, "
+                                  f"{job_id} still running")
+                    job_ids.append(job_id)
+        # Update cache
+        logging.debug("SlurmRunner: updating the cache")
+        self._cached_job_list_timestamp = time.time()
+        self._cached_job_list = [j for j in job_ids]
+        self._cached_job_list_force_update = False
+        # Add the jobs in the grace period
+        for job_id in grace_period_jobs:
+            if job_id not in job_ids:
+                job_ids.append(job_id)
+            else:
+                # Job now visible so no longer in grace period
+                self._update_job_in_grace_period(job_id)
+        logging.debug("SlurmRunner: 'list' returning %s" % job_ids)
+        return job_ids
+
+    def exit_status(self,job_id):
+        """
+        Return exit status from command run by a job
+
+        If the job is still running then returns 'None'.
+        """
+        if self.isRunning(job_id):
+            # Return None if job is still running
+            return None
+        # Check if job is being finalized
+        start_time = time.time()
+        while job_id in self._finalizing:
+            # Wait until exit_status is ready
+            time.sleep(1.0)
+            if (time.time() - start_time) > self._timeout:
+                logging.warning("SlurmRunner: timed out waiting "
+                                "for job %s to finalize" % job_id)
+                return None
+        # Return cached exit status
+        return self._exit_status[job_id]
+
+    def _make_admin_dir(self):
+        """
+        Internal: create temporary directory for admin
+
+        The directory will be created in a subdirectory of
+        the current working directory.
+        """
+        if self._admin_dir:
+            # Return current value, if set
+            return self._admin_dir
+        # Create a new temporary directory
+        self._admin_dir = tempfile.mkdtemp(prefix=".slurmrunner.",
+                                           dir=os.getcwd())
+        return self._admin_dir
+
+    def _clean_up_admin_dir(self):
+        """
+        Internal: remove the admin dir
+
+        Shouldn't be called directly; instead register with
+        'atexit' to force clean up on program exit
+        """
+        logging.debug("SlurmRunner: removing admin dir '%s'" %
+                      self._admin_dir)
+        # Check if jobs are still being finalized
+        start_time = time.time()
+        while self._finalizing:
+            # Wait until everything has finalized
+            time.sleep(1.0)
+            if (time.time() - start_time) > self._timeout:
+                logging.warning("SlurmRunner: timed out waiting "
+                                "for jobs to finalize")
+                break
+        # Try to remove the admin dir and contents
+        try:
+            shutil.rmtree(self._admin_dir)
+        except Exception as ex:
+            logging.warning("SlurmRunner: exception removing "
+                            "admin dir '%s': %s" %
+                            (self._admin_dir, ex))
+
+    def _update_job_in_grace_period(self,job_id):
+        """
+        Internal: handling update of job in grace period
+
+        Checks if a job is still within the grace period
+        (i.e. has an entry in the `_start_time`
+        dictionary which is newer than the grace period).
+
+        If the job is no longer in the grace period then
+        removes its entry in the `_start_time`
+        dictionary.
+        """
+        logging.debug("SlurmRunner: checking if job %s is still in "
+                      "grace period" % job_id)
+        lock = None
+        while lock is None:
+            lock = self._updating_grace_period.acquire(job_id)
+        logging.debug("SlurmRunner: acquired lock for grace period "
+                      "update: %s" % lock)
+        try:
+            start_time = self._start_time[job_id]
+        except KeyError:
+            logging.debug("SlurmRunner: update grace period: job %s "
+                          "has gone away (ignored)" % job_id)
+            self._updating_grace_period.release(lock)
+            return
+        if ((time.time() - start_time) > self._new_job_grace_period):
+            # Job no longer in grace period
+            logging.debug("SlurmRunner: job %s no longer in grace "
+                          "period" % job_id)
+            try:
+                del(self._start_time[job_id])
+            except KeyError:
+                logging.debug("SlurmRunner: update grace period: "
+                              "job %s has gone away (ignored)" %
+                              job_id)
+        # Release update lock
+        self._updating_grace_period.release(lock)
+
+    def _handle_job_completion(self,job_id):
+        """
+        Internal: deal with completion of job
+
+        Peforms the following operations:
+
+        - checks that an '__exit_code' file exists for
+          the job
+        - read and store the exit status/return code from
+          this file
+        - ensure that the queue is set for the job
+        - call the clean up function to remove all the
+          associated files
+        - remove the job from the internal job count
+
+        If the '__exit_code' file associated with the job
+        can't be found after a number of attempts to locate
+        it, or if the exit status cannot be read from the
+        file, then the exit status for the job will be
+        set to '127'.
+        """
+        logging.debug("SlurmRunner: handle job completion for %s"
+                      % job_id)
+        lock = None
+        while lock is None:
+            lock = self._job_lock.acquire(job_id)
+        logging.debug("SlurmRunner: acquired lock: %s" % lock)
+        if job_id not in self._job_number:
+            # Job has gone away
+            logging.debug("SlurmRunner: job %s has gone away" %
+                          job_id)
+            self._job_lock.release(lock)
+            return
+        self._finalizing[job_id] = True
+        # Check there is an exit code file
+        exit_code_file = os.path.join(self._admin_dir,
+                                      str(self._job_number[job_id]),
+                                      "__exit_code")
+        assert(os.path.exists(exit_code_file))
+        try:
+            with open(exit_code_file,'rt') as fp:
+                exit_status = int(fp.read())
+        except Exception as ex:
+            # Set exit status to 127
+            logging.error("SlurmRunner: exception when "
+                          "reading exit_status for job "
+                          "%s: %s" % (job_id, ex))
+            exit_status = 127
+        # Store exit status and clean up
+        self._exit_status[job_id] = exit_status
+        self._clean_up_job(job_id)
+        # Release finalization lock
+        del(self._finalizing[job_id])
+        # Release job lock
+        self._job_lock.release(lock)
+
+    def _clean_up_job(self,job_id):
+        """
+        Internal: clean up internal job files
+
+        Removes the internal directory associated with a job, along
+        with any files it contains (e.g. job script, exit code etc).
+
+        This method should only be invoked for jobs that have
+        finished running. If the job is still running then returns
+        with no action.
+        """
+        # Do clean up
+        logging.debug("SlurmRunner: cleaning up after job %s" % job_id)
+        try:
+            job_number = self._job_number[job_id]
+        except KeyError:
+            logging.error("SlurmRunner: job %d not found, can't do "
+                          "clean up" % job_id)
+            return
+        job_dir = os.path.join(self._admin_dir, str(job_number))
+        try:
+            # Remove the directory and contents
+            shutil.rmtree(job_dir)
+        except Exception as ex:
+            logging.warning("SlurmRunner: exception cleaning up for "
+                            "job %s (ignored): %s" % (job_id, ex))
+        # Clear stored error state
+        try:
+            del(self._error_state[job_id])
+        except KeyError:
+            pass
+        # Remove the internally stored job number
+        del(self._job_number[job_id])
+
+    def _run_squeue(self):
+        """
+        Internal: run squeue and return data as a list of lists
+
+        Runs 'squeue' command, processes the output and returns a
+        list where each item is the data for a job in the form of
+        another list, with the items in this list being the data
+        returned by squeue.
+
+        NB as 'squeue' calls can be relatively expensive to make,
+        the output from 'squeue' is cached for a specified period
+        before being refreshed.
+        """
+        # Should we return the cached data?
+        if (time.time() - self._cached_squeue_output_timestamp) < \
+           self._cached_squeue_output_lifetime:
+            logging.debug("SlurmRunner: returning cached squeue output")
+            return self._cached_squeue_output
+        # Run squeue and collect the output
+        try:
+            cmd = ["squeue", "--user", os.getlogin()]
+        except OSError:
+            # os.getlogin() not guaranteed to work in all environments?
+            cmd = ["squeue", "--me"]
+        # Run squeue command
+        p = subprocess.Popen(cmd,
+                             stdout=subprocess.PIPE,
+                             universal_newlines=True)
+        stdoutdata = p.communicate()[0]
+        logging.debug(f"SlurmRunner: output from 'squeue': {stdoutdata}")
+        # Process the output
+        squeue_output = []
+        # Output has a header line with field names then one
+        # line per job
+        lines = stdoutdata.rstrip("\n").split("\n")
+        fields = lines[0].split()
+        idx_jobid = fields.index("JOBID")
+        idx_state = fields.index("ST")
+        for line in lines[1:]:
+            # Store tuples of jobid, state
+            data = line.split()
+            try:
+                squeue_output.append((data[idx_jobid], data[idx_state]))
+            except IndexError:
+                logging.debug(f"SlurmRunner: failed to parse 'squeue' "
+                              f"output: '{line}' (ignored)")
+        # Update the cache
+        self._cached_squeue_output_timestamp = time.time()
+        self._cached_squeue_output = squeue_output
+        return squeue_output
+
+    def _job_state_code(self, job_id):
+        """
+        Internal: get the state code for a job id
+
+        Will be one of the Slurm job state codes, or an empty
+        string if the job id isn't found.
+        """
+        # Run squeue and process output to get job states
+        logging.debug("SlurmRunner: acquiring state for job %s"
+                      % job_id)
+        squeue = self._run_squeue()
+        job_ids = []
+        job_states = {}
+        for job_data in squeue:
+            id_ = job_data[0]
+            state = job_data[1]
+            logging.debug(f"SlurmRunner: found job {id_} (state '{state}')")
+            if id_ == job_id:
+                return state
+        # Job not found
+        return ""
+
+    def _sanitize_job_name(self, name):
+        """
+        Internal: sanitize a job name for use with Slurm
+
+        This is copied from the GE runner
+        """
+        sanitized_name = str(name)
+        for c in ":*@\\?":
+            sanitized_name = sanitized_name.replace(c,'_')
+        if sanitized_name[0].isdigit():
+            # If name starts with a digit then prepend
+            # an underscore
+            sanitized_name = f"_{sanitized_name}"
+        return sanitized_name
+
+    def _check_slurm_extra_args(self):
+        """
+        Internal: check extra arguments provided for Slurm
+
+        The -n and -p options implicitly set the number of
+        slots and the target partition, but only if not
+        explicitly set when the runner was instantiated
+        (otherwise an exception is raised).
+
+        The extra arguments list is updated to remove the
+        explicit -n and -p options.
+
+        The -J, -o, -e and --export options are reserved for
+        exclusive use by the runner so if these are specified
+        then an exception is raised.
+        """
+        if self._slurm_extra_args is None:
+            return
+        args = [x for x in self._slurm_extra_args]
+        new_args = []
+        while args:
+            # Grab first argument and update the list
+            arg = args[0]
+            args = args[1:]
+            # Check for specific arguments
+            if arg == "-n":
+                if self._nslots is None:
+                    self._nslots = int(args[0])
+                    args = args[1:]
+                else:
+                    raise Exception(f"SlurmRunner: '-n' not permitted "
+                                    f"in extra arguments if nslots is set")
+            elif arg == "-p":
+                if self._partition is None:
+                    self._partition = str(args[0])
+                    args = args[1:]
+                else:
+                    raise Exception(f"SlurmRunner: '-p' not permitted "
+                                    f"in extra arguments if partition is set")
+            elif arg in ("-J", "-o", "-e") or \
+                 arg == "--export" or arg.startswith("--export="):
+                raise Exception(f"SlurmRunner: '{arg}' not permitted "
+                                f"in extra arguments")
+            else:
+                new_args.append(arg)
+        # Update the extra arguments
+        self._slurm_extra_args = new_args
+
 
 class ResourceLock:
     """

--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -1513,17 +1513,15 @@ exit $exit_code
             logging.debug("SlurmRunner: using cached job list")
             job_ids = self._cached_job_list
             # Add the jobs in grace period
-            grace_period_jobs = list(self._start_time.keys())
-            for job_id in grace_period_jobs:
+            for job_id in self._grace_period_jobs():
                 if job_id not in job_ids:
                     job_ids.append(job_id)
             return job_ids
         else:
             logging.debug("SlurmRunner: building job list")
         # Update jobs in grace period
-        for job_id in list(self._start_time.keys()):
+        for job_id in self._grace_period_jobs():
             self._update_job_in_grace_period(job_id)
-        grace_period_jobs = list(self._start_time.keys())
         # Build initial list from directory contents
         job_ids = []
         for job_id in list(self._job_number.keys()):
@@ -1555,7 +1553,7 @@ exit $exit_code
         self._cached_job_list = [j for j in job_ids]
         self._cached_job_list_force_update = False
         # Add the jobs in the grace period
-        for job_id in grace_period_jobs:
+        for job_id in self._grace_period_jobs():
             if job_id not in job_ids:
                 job_ids.append(job_id)
             else:
@@ -1625,6 +1623,16 @@ exit $exit_code
             logging.warning("SlurmRunner: exception removing "
                             "admin dir '%s': %s" %
                             (self._admin_dir, ex))
+
+    def _grace_period_jobs(self):
+        """
+        Internal: return list of jobs in the grace period
+
+        Returns list of job IDs where each job has an entry
+        in the `_start_time` dictionary which is newer than
+        the grace period timeout.
+        """
+        return list(self._start_time.keys())
 
     def _update_job_in_grace_period(self,job_id):
         """

--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -1441,7 +1441,7 @@ exit $exit_code
         # Return the job id
         return job_id
 
-    def terminate(self, job_id):
+    def terminate(self, job_id, exit_code=-1):
         """
         Remove a job from the Slurm queue using 'scancel'
         """
@@ -1458,7 +1458,7 @@ exit $exit_code
                                       str(self._job_number[job_id]),
                                       "__exit_code")
         with open("%s.tmp" % exit_code_file, "wt") as fp:
-            fp.write("-1\n")
+            fp.write(f"{exit_code}\n")
         os.rename("%s.tmp" % exit_code_file, exit_code_file)
         # Force update of cached job list
         self._cached_job_list_force_update = True

--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -1223,7 +1223,7 @@ class SlurmRunner(BaseJobRunner):
         self._cached_job_list = []
         self._cached_job_list_force_update = True
         # Cached qstat output
-        self._cached_squeue_output_lifetime = 2.0
+        self._cached_squeue_output_lifetime = 0.5
         self._cached_squeue_output_timestamp = 0.0
         self._cached_squeue_output = None
         # Grace period for new jobs

--- a/bcftbx/JobRunner.py
+++ b/bcftbx/JobRunner.py
@@ -1562,6 +1562,7 @@ exit $exit_code
             if check_missing_jobs:
                 logging.debug(f"SlurmRunner: checking for missing jobs")
                 job_ids = self._handle_missing_jobs(job_ids)
+                self._missing_job_last_checked = time.time()
         # Update cache
         logging.debug("SlurmRunner: updating the cache")
         self._cached_job_list_timestamp = time.time()

--- a/bcftbx/mockslurm.py
+++ b/bcftbx/mockslurm.py
@@ -594,7 +594,7 @@ echo "$exit_code" 1>%s/__exit_code.%d
             else:
                 nodelist = "mock-node01"
             line = f"{job_id:>18} {partition:>9} {name:>8} {user:>8} {state:>2} {job_time:>10.2} {num_nodes:>6} {nodelist}"
-            prin(line)
+            print(line)
 
     def scancel(self,argv):
         """

--- a/bcftbx/mockslurm.py
+++ b/bcftbx/mockslurm.py
@@ -563,10 +563,9 @@ echo "$exit_code" 1>%s/__exit_code.%d
             user = args.user
         # Get jobs
         jobs = self._list_jobs(user=user)
-        if not jobs:
-            return
-        # Print job info
+        # Print header even if there are no jobs to report
         print("             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)")
+        # Print info for each job
         # From manpage, default output string is:
         # "%.18i %.9P %.8j %.8u %.2t %.10M %.6D %R"
         # where . indicates right-justified (otherwise left-justified)

--- a/bcftbx/mockslurm.py
+++ b/bcftbx/mockslurm.py
@@ -1,0 +1,658 @@
+#     mockslurm.py: mock Slurm functionality for testing
+#     Copyright (C) University of Manchester 2025 Peter Briggs
+#
+#######################################################################
+
+"""
+Utility class for simulating Slurm functionality
+
+Provides a single class `MockSlurm`, which implements methods for
+simulating the functionality provided by the Slurm command
+line utilities, and a function `setup_mock_slurm`, which creates
+mock versions of those utilities ('sbatch', 'squeue', and 'scancel').
+"""
+
+#######################################################################
+# Imports
+#######################################################################
+
+import os
+import sys
+import sqlite3
+import argparse
+import subprocess
+import getpass
+import time
+import datetime
+import logging
+import atexit
+
+#######################################################################
+# Classes
+#######################################################################
+
+class MockSlurm:
+    """
+    Class implementing sbatch, squeue & scancel-like functionality
+
+    Job data is stored in an SQLite3 database in the 'database
+    directory' (defaults to '$HOME/.mockslurm'); scripts and job
+    exit status files are also written to this directory.
+
+    The following methods can be invoked which provide functions
+    similar to their Slurm namesakes:
+
+    - sbatch: submits a job to be run
+    - squeue: outputs information on active jobs
+    - scancel: terminates an active job
+
+    Each time any of these are invoked, the 'update_jobs' method is
+    called to check the status of any active jobs and update the
+    database accordingly; this method can also be invoked directly.
+
+    NB the 'stop' method should be invoked on the 'MockSlurm'
+    instance when it is not longer needed, to ensure that any
+    running processes are properly terminated.
+
+    Arguments:
+      max_jobs (int): maximum number of jobs to run at
+        once; additional jobs will be queued
+      sbatch_delay (float): minimum time in seconds that must
+        elapse from 'sbatch' command to job registering and
+        appearing in 'squeue' output
+      shell (str): shell to run internal scripts using
+        database_dir (str): path to directory used for
+        managing the mockslurm functionality (defaults to
+        '$HOME/.mockslurm')
+      debug (bool): if True then turn on debugging output
+    """
+    def __init__(self, max_jobs=4, sbatch_delay=0.0, shell='/bin/bash',
+                 database_dir=None, debug=False):
+        """
+        Create a new MockSlurm instance
+        """
+        if debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+        if database_dir is None:
+            database_dir = os.path.join(self._user_home(),
+                                        ".mockslurm")
+        self._database_dir = os.path.abspath(database_dir)
+        self._db_file = os.path.join(self._database_dir,
+                                     "mockslurm.sqlite")
+        self._processes = []
+        if not os.path.exists(self._database_dir):
+            os.mkdir(self._database_dir)
+        init_db = False
+        if not os.path.exists(self._db_file):
+            init_db = True
+        try:
+            logging.debug("Connecting to DB")
+            self._cx = sqlite3.connect(self._db_file)
+            self._cx.row_factory = sqlite3.Row
+        except Exception as ex:
+            print("Exception connecting to DB: %s" % ex)
+            raise ex
+        if init_db:
+            logging.debug("Setting up DB")
+            self._init_db()
+        self._shell = shell
+        self._max_jobs = max_jobs
+        self._sbatch_delay = sbatch_delay
+        atexit.register(self.stop)
+
+    def stop(self):
+        """
+        Terminate running jobs when MockSlurm class no longer needed
+        """
+        self._cleanup_processes()
+
+    def _init_db(self):
+        """
+        Set up the persistent database
+        """
+        sql = """
+        CREATE TABLE jobs (
+          id          INTEGER PRIMARY KEY,
+          user        CHAR,
+          state       CHAR,
+          name        VARCHAR,
+          command     VARCHAR,
+          working_dir VARCHAR,
+          nslots      INTEGER,
+          partition   VARCHAR,
+          output_tmpl CHAR,
+          error_tmpl  CHAR,
+          export      CHAR,
+          pid         INTEGER,
+          sbatch_time FLOAT,
+          start_time  FLOAT,
+          end_time    FLOAT,
+          exit_code   INTEGER
+        )
+        """
+        try:
+            cu = self._cx.cursor()
+            cu.execute(sql)
+            self._cx.commit()
+        except sqlite3.Error as ex:
+            print("Failed to set up database: %s" % ex)
+            raise ex
+
+    def _init_job(self, name, command, working_dir, nslots, partition,
+                  output_tmpl, error_tmpl, export):
+        """
+        Create a new job id
+        """
+        cmd = []
+        for arg in command:
+            try:
+                arg.index(' ')
+                arg = '"%s"' % arg
+            except ValueError:
+                pass
+            cmd.append(arg)
+        command = ' '.join(cmd)
+        logging.debug(f"_init_job: cmd: {cmd}")
+        try:
+            sql = """
+            INSERT INTO jobs (user,state,sbatch_time,name,command,working_dir,nslots,partition,output_tmpl,error_tmpl,export)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """
+            cu = self._cx.cursor()
+            cu.execute(sql,(self._user(),
+                            'PD',
+                            time.time(),
+                            name,
+                            command,
+                            working_dir,
+                            nslots,
+                            partition,
+                            output_tmpl,
+                            error_tmpl,
+                            export))
+            self._cx.commit()
+            return cu.lastrowid
+        except Exception as ex:
+            logging.error(f"sbatch failed with exception: {ex}")
+
+    def _start_job(self, job_id):
+        """
+        Start a job running
+        """
+        # Get job info
+        sql = """
+        SELECT name,command,nslots,partition,working_dir,output_tmpl,error_tmpl
+        FROM jobs WHERE id==?
+        """
+        cu = self._cx.cursor()
+        cu.execute(sql,(job_id,))
+        job = cu.fetchone()
+        name = job['name']
+        command = job['command']
+        nslots = job['nslots']
+        partition = job['partition']
+        working_dir = job['working_dir']
+        output_tmpl = job['output_tmpl']
+        error_tmpl = job['error_tmpl']
+        # Try to run the job
+        try:
+            # Output file basename
+            out = os.path.join(working_dir, output_tmpl)
+            logging.debug(f"Output basename: {out}")
+            # Error file basename
+            if error_tmpl:
+                err = os.path.join(working_dir, error_tmpl)
+            else:
+                err = None
+            # Set up stdout and stderr targets
+            stdout_file = out.\
+                          replace("%j", str(job_id)).\
+                          replace("%x", str(name))
+            logging.debug("Stdout: %s" % stdout_file)
+            redirect = "1>%s" % stdout_file
+            if err:
+                stderr_file = err.\
+                              replace("%j", str(job_id)).\
+                              replace("%x", str(name))
+                logging.debug("Stderr: %s" % stderr_file)
+                redirect = "%s 2>%s" % (redirect, stderr_file)
+            else:
+                redirect = "%s 2>&1" % redirect
+            # Build a script to run the command
+            script_file = os.path.join(self._database_dir,
+                                       f"__job{job_id}.sh")
+            with open(script_file, "wt") as fp:
+                fp.write(u"""#!%s
+SLURM_NTASKS=%s SLURM_JOB_ID=%s SLURM_JOB_NAME=%s %s %s
+exit_code=$?
+echo "$exit_code" 1>%s/__exit_code.%d
+""" % (self._shell, nslots, job_id, name, command, redirect,
+       self._database_dir, job_id))
+            os.chmod(script_file,0o775)
+            with open(script_file, "rt") as fp:
+                print(f"Job script from {script_file}:")
+                for line in fp:
+                    line = line.rstrip('\n')
+                    print(f">>> {line}")
+            # Run the command and capture process id
+            process = subprocess.Popen(script_file,
+                                       cwd=working_dir,
+                                       close_fds=True,
+                                       stdout=subprocess.PIPE,
+                                       stderr=subprocess.STDOUT,
+                                       preexec_fn=os.setpgrp)
+            pid = process.pid
+            # Store process object
+            self._processes.append(process)
+            # Update the database
+            sql = """
+            UPDATE jobs SET pid=?,state='R',start_time=?
+            WHERE id=?
+            """
+            cu = self._cx.cursor()
+            cu.execute(sql,(pid,time.time(),job_id))
+            self._cx.commit()
+        except Exception as ex:
+            # Put job into error state
+            logging.debug("Exception trying to start job '%s'"
+                          % job_id)
+            logging.debug("%s" % ex)
+            sql = """
+            UPDATE jobs SET state='F',start_time=?
+            WHERE id=?
+            """
+            cu = self._cx.cursor()
+            cu.execute(sql,(time.time(),job_id))
+            self._cx.commit()
+
+    def update_jobs(self):
+        """
+        Update all job info
+        """
+        # Get jobs that have finished running
+        cu = self._cx.cursor()
+        sql = """
+        SELECT id,pid FROM jobs WHERE state=='R'
+        """
+        cu.execute(sql)
+        jobs = cu.fetchall()
+        finished_jobs = []
+        for job in jobs:
+            job_id = job['id']
+            pid = job['pid']
+            try:
+                # See https://stackoverflow.com/a/7647264/579925
+                logging.debug("Checking job=%d pid=%d" % (job_id,pid))
+                os.kill(pid, 0)
+            except Exception as ex:
+                logging.debug("Exception: %s" % ex)
+                finished_jobs.append(job_id)
+        logging.debug("Finished jobs: %s" % finished_jobs)
+        for job_id in finished_jobs:
+            # Clean up
+            script_file = os.path.join(self._database_dir,
+                                       "__job%d.sh" % job_id)
+            if os.path.exists(script_file):
+                os.remove(script_file)
+            # Exit code
+            exit_code_file = os.path.join(self._database_dir,
+                                          "__exit_code.%d" % job_id)
+            if os.path.exists(exit_code_file):
+                end_time = os.path.getctime(exit_code_file)
+                with open(exit_code_file, 'rt') as fp:
+                    exit_code = int(fp.read())
+                os.remove(exit_code_file)
+            else:
+                logging.error("Missing __exit_code file for job %s"
+                              % job_id)
+                end_time = time.time()
+                exit_code = 1
+            # Update database
+            sql = """
+            UPDATE jobs SET state='c',exit_code=?,end_time=?
+            WHERE id==?
+            """
+            logging.debug(f"SQL: {sql}")
+            cu.execute(sql, (exit_code, end_time, job_id))
+        if finished_jobs:
+            self._cx.commit()
+        # Deal with jobs that are marked for deletion
+        sql = """
+        SELECT id FROM jobs WHERE state == 'CA'
+        """
+        cu.execute(sql)
+        jobs = cu.fetchall()
+        deleted_jobs = [job['id'] for job in jobs]
+        for job_id in deleted_jobs:
+            sql = """
+            SELECT pid FROM jobs WHERE id==?
+            """
+            cu.execute(sql, (job_id,))
+            job = cu.fetchone()
+            if job is None:
+                continue
+            # Try to stop the job
+            try:
+                pid = int(job['pid'])
+                os.kill(pid, 9)
+            except Exception:
+                pass
+            # Update the database
+            sql = """
+            UPDATE jobs SET state='c' WHERE id=?
+            """
+            cu.execute(sql, (job_id,))
+            self._cx.commit()
+            # Remove any files
+            for name in ("__job%d.sh" % job_id,
+                         "__exit_code.%d" % job_id):
+                try:
+                    os.remove(os.path.join(self._database_dir,
+                                           name))
+                except OSError:
+                    pass
+            # Exit code
+            exit_code_file = os.path.join(self._database_dir,
+                                          "__exit_code.%d" % job_id)
+        # Deal with jobs that are waiting
+        sql = """
+        SELECT id,sbatch_time FROM jobs WHERE state == 'PD'
+        """
+        cu.execute(sql)
+        waiting_jobs = cu.fetchall()
+        for job in waiting_jobs:
+            # Adds a delay to jobs going from pending to running
+            if (time.time() - job["sbatch_time"]) < self._sbatch_delay:
+                logging.debug(f"Job {job['id']} not ready to go to 'R'")
+                continue
+            sql = """
+            SELECT id FROM jobs WHERE state=='R'
+            """
+            cu.execute(sql)
+            nrunning = len(cu.fetchall())
+            if nrunning < self._max_jobs:
+                self._start_job(job["id"])
+            else:
+                break
+
+    def _list_jobs(self, user, state=None):
+        """
+        Get list of the jobs
+        """
+        sql = """
+        SELECT id,name,user,state,sbatch_time,start_time,partition FROM jobs WHERE state != 'c'
+        """
+        args = []
+        if user != "\\*" and user != "*":
+            sql += "AND user == ?"
+            args.append(user)
+        cu = self._cx.cursor()
+        cu.execute(sql, args)
+        return cu.fetchall()
+
+    def _job_info(self, job_id):
+        """
+        Return info on a job
+        """
+        sql = """
+        SELECT id,name,user,exit_code,sbatch_time,start_time,end_time,partition
+        FROM jobs WHERE id==? AND state=='c'
+        """
+        cu = self._cx.cursor()
+        cu.execute(sql,(job_id,))
+        return cu.fetchone()
+
+    def _mark_for_deletion(self, job_id):
+        """
+        Mark a job for termination/deletion
+        """
+        # Look up the job and check it can be deleted
+        sql = """
+        SELECT state FROM jobs WHERE id=?
+        """
+        cu = self._cx.cursor()
+        cu.execute(sql, (job_id,))
+        job = cu.fetchone()
+        if job is None:
+            return
+        state = job['state']
+        if state not in ('PD', 'R', 'F'):
+            return
+        new_state = 'CA'
+        sql = """
+        UPDATE jobs SET state=? WHERE id=?
+        """
+        cu = self._cx.cursor()
+        cu.execute(sql,(new_state,job_id,))
+        self._cx.commit()
+
+    def _cleanup_processes(self):
+        """
+        Do clean up (i.e. termination) of processes on exit
+        """
+        logging.debug("Doing cleanup for exit")
+        # Stop jobs that are still running
+        cu = self._cx.cursor()
+        sql = """
+        SELECT id,pid FROM jobs WHERE state=='r'
+        """
+        cu.execute(sql)
+        jobs = cu.fetchall()
+        for job in jobs:
+            job_id = job['id']
+            pid = job['pid']
+            try:
+                logging.debug("Checking job=%d pid=%d" % (job_id,pid))
+                os.kill(pid,9)
+            except Exception as ex:
+                pass
+        for process in self._processes:
+            process.kill()
+
+    def _user(self):
+        """
+        Get the current user name
+        """
+        return getpass.getuser()
+
+    def _user_home(self):
+        """
+        Get the current user home directory
+        """
+        return os.path.expanduser("~%s" % self._user())
+
+    def sbatch(self, argv):
+        """
+        Implement sbatch-like functionality
+        """
+        # Process supplied arguments
+        p = argparse.ArgumentParser()
+        p.add_argument("-J", "--job-name", action="store", dest="job_name")
+        p.add_argument("-p", "--partition", action="store",
+                       dest="partition", default="default")
+        p.add_argument("-n", "--ntasks", action="store", type=int,
+                       dest="ntasks", default=1)
+        p.add_argument("-o", "--output", action="store", dest="output")
+        p.add_argument("-e", "--error", action="store", dest="error")
+        p.add_argument("--export", action="store", default="ALL")
+        p.add_argument("--chdir", action="store")
+        args,cmd = p.parse_known_args(argv)
+        # Command
+        logging.debug(f"sbatch: cmd: {cmd}")
+        if len(cmd) == 1:
+            cmd = cmd[0].split(' ')
+        # Job name
+        if args.job_name is not None:
+            name = str(args.job_name)
+        else:
+            name = cmd[0].split(' ')[0]
+        logging.debug(f"Name: {name}")
+        # Working directory
+        if args.chdir:
+            working_dir = os.path.abspath(args.chdir)
+        else:
+            working_dir = os.getcwd()
+        logging.debug("Working dir: %s" % working_dir)
+        # Number of cores
+        nslots = args.ntasks
+        # Partition
+        partition = args.partition
+        # Export environment
+        export = args.export
+        # Output and error file name templates
+        if args.output:
+            output_tmpl = args.output
+        else:
+            output_tmpl = "slurm-%j.out"
+        if args.error:
+            error_tmpl = args.error
+        else:
+            error_tmpl = None
+        # Create an initial entry in job table
+        job_id = self._init_job(name, cmd, working_dir, nslots, partition,
+                                output_tmpl, error_tmpl, export)
+        logging.debug("Created job %s" % job_id)
+        # Report the job id
+        print(f"Submitted batch job {job_id}")
+        self.update_jobs()
+        return job_id
+
+    def squeue(self, argv):
+        """
+        Implement squeue-like functionality
+        """
+        # Example squeue output (from
+        # https://docs.hpc.shef.ac.uk/en/latest/referenceinfo/scheduler/SLURM/Common-commands/squeue.html#gsc.tab=0):
+        #        JOBID   PARTITION   NAME      USER  ST       TIME  NODES NODELIST(REASON)
+        #        1234567 interacti   bash   foo1bar   R   17:19:40      1 bessemer-node001
+        #        1234568 sheffield job.sh   foo1bar   R   17:21:40      1 bessemer-node046
+        #        1234569 sheffield job.sh   foo1bar  PD   17:22:40      1 (Resources)
+        #        1234570 sheffield job.sh   foo1bar  PD   16:47:06      1 (Priority)
+        #        1234571       gpu job.sh   foo1bar   R 1-19:46:53      1 bessemer-node026
+        #        1234572       gpu job.sh   foo1bar   R 1-19:46:54      1 bessemer-node026
+        #        1234573       gpu job.sh   foo1bar   R 1-19:46:55      1 bessemer-node026
+        #        1234574       gpu job.sh   foo1bar   R 1-19:46:56      1 bessemer-node026
+        #        1234575       gpu job.sh   foo1bar  PD       9:04      1 (ReqNodeNotAvail, UnavailableNodes:bessemer-node026)
+        #        1234576 sheffield job.sh   foo1bar  PD    2:57:24      1 (QOSMaxJobsPerUserLimit)
+        #
+        # Job states that are relevant here:
+        #
+        # CA = cancelled by user or admin
+        # PD = pending
+        # R = running
+        # S = suspended
+        # CG = completing
+        # CD = completed
+        #
+        # Update the db
+        self.update_jobs()
+        # Process supplied arguments
+        p = argparse.ArgumentParser()
+        p.add_argument("--user",action="store")
+        p.add_argument("--me",action="store_true")
+        args = p.parse_args(argv)
+        # User
+        user = None
+        if args.me:
+            user = self._user()
+        else:
+            user = args.user
+        # Get jobs
+        jobs = self._list_jobs(user=user)
+        if not jobs:
+            return
+        # Print job info
+        print("             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)")
+        # From manpage, default output string is:
+        # "%.18i %.9P %.8j %.8u %.2t %.10M %.6D %R"
+        # where . indicates right-justified (otherwise left-justified)
+        # and number is minimum field size
+        #
+        # The letters are:
+        # - i = job id
+        # - P = partition
+        # - j = job name
+        # - u = user
+        # - t = job state (compact form)
+        # - M = time used by the job (H:M:S)
+        # - D = number of nodes
+        # - R = reason why it's pending (pending jobs), reason for
+        #        failure (failed jobs), list of nodes (all others)
+        for job in jobs:
+            job_id = str(job["id"])
+            partition = str(job["partition"])
+            name = str(job["name"])
+            user = job["user"]
+            state = job["state"]
+            job_time = job["start_time"]
+            if job_time is None:
+                job_time = job["sbatch_time"]
+            job_time = time.time() - job_time
+            num_nodes = 1
+            if state == "PD":
+                nodelist = "(Resources)"
+            else:
+                nodelist = "mock-node01"
+            line = f"{job_id:>18} {partition:>9} {name:>8} {user:>8} {state:>2} {job_time:>10.2} {num_nodes:>6} {nodelist}"
+            prin(line)
+
+    def scancel(self,argv):
+        """
+        Implement scancel-like functionality
+        """
+        logging.debug("scancel: invoked")
+        # Update the db
+        self.update_jobs()
+        # Process supplied arguments
+        p = argparse.ArgumentParser()
+        p.add_argument("job_id",action="store",nargs="+")
+        args = p.parse_args(argv)
+        # Loop over job ids
+        for job_id in args.job_id:
+            job_id = int(job_id)
+            # Mark the job for deletion
+            self._mark_for_deletion(job_id)
+            # FIXME check what message scancel actually prints
+            print("Job %s has been marked for deletion" % job_id)
+
+#######################################################################
+# Functions
+#######################################################################
+
+def _make_mock_slurm_exe(path, f, database_dir=None, debug=None,
+                         sbatch_delay=None):
+    """
+    Internal helper function to create utilities
+    """
+    args = []
+    if database_dir is not None:
+        args.append(f"database_dir='{database_dir}'")
+    if sbatch_delay is not None:
+        args.append(f"sbatch_delay={sbatch_delay}")
+    if debug is not None:
+        args.append(f"debug={debug}")
+    with open(path,'w') as fp:
+        fp.write(u"""#!/usr/bin/env python
+import sys
+from bcftbx.mockslurm import MockSlurm
+sys.exit(MockSlurm(%s).%s(sys.argv[1:]))
+""" % (','.join(args),f))
+    os.chmod(path,0o775)
+
+def setup_mock_slurm(bindir=None, database_dir=None, debug=None,
+                     sbatch_delay=None):
+    """
+    Creates mock 'sbatch', 'squeue' and 'scancel' exes
+    """
+    # Bin directory
+    if bindir is None:
+        bindir = os.getcwd()
+    bindir = os.path.abspath(bindir)
+    # Utilities
+    for utility in ("sbatch", "squeue", "scancel"):
+        path = os.path.join(bindir,utility)
+        _make_mock_slurm_exe(path,
+                             utility,
+                             database_dir=database_dir,
+                             sbatch_delay=sbatch_delay,
+                             debug=debug)

--- a/bcftbx/test/test_JobRunner.py
+++ b/bcftbx/test/test_JobRunner.py
@@ -1015,7 +1015,10 @@ class TestSlurmRunner(unittest.TestCase):
         Test SlurmRunner handles job terminated externally
         """
         # Create a runner
-        runner = SlurmRunner(poll_interval=1.0)
+        # NB reduce the poll interval and missing job timeout
+        # so test will run in a reasonable time
+        runner = SlurmRunner(poll_interval=1.0,
+                             missing_job_timeout=1.0)
         self.assertEqual(runner.nslots, 1)
         self.assertEqual(runner.partition, None)
         self.assertFalse(runner.join_logs)
@@ -1040,7 +1043,10 @@ class TestSlurmRunner(unittest.TestCase):
         Test SlurmRunner handles job terminated externally alongside normal job
         """
         # Create a runner
-        runner = SlurmRunner(poll_interval=1.0)
+        # NB reduce the poll interval and missing job timeout
+        # so test will run in a reasonable time
+        runner = SlurmRunner(poll_interval=1.0,
+                             missing_job_timeout=1.0)
         self.assertEqual(runner.nslots, 1)
         self.assertEqual(runner.partition, None)
         self.assertFalse(runner.join_logs)

--- a/bcftbx/test/test_JobRunner.py
+++ b/bcftbx/test/test_JobRunner.py
@@ -1079,6 +1079,73 @@ class TestFetchRunnerFunction(unittest.TestCase):
         self.assertTrue(isinstance(runner,GEJobRunner))
         self.assertEqual(runner.ge_extra_args,['-j','y'])
 
+    def test_fetch_slurm_runner(self):
+        """fetch_runner returns a SlurmRunner
+        """
+        runner = fetch_runner("SlurmRunner")
+        self.assertTrue(isinstance(runner, SlurmRunner))
+        self.assertEqual(runner.nslots, 1)
+        self.assertEqual(runner.partition, None)
+        self.assertFalse(runner.join_logs)
+        self.assertEqual(runner.slurm_extra_args, None)
+
+    def test_fetch_slurm_runner_with_nslots(self):
+        """fetch_runner returns a SlurmRunner with nslots
+        """
+        runner = fetch_runner("SlurmRunner(nslots=8)")
+        self.assertTrue(isinstance(runner, SlurmRunner))
+        self.assertEqual(runner.nslots, 8)
+        self.assertEqual(runner.partition, None)
+        self.assertFalse(runner.join_logs)
+        self.assertEqual(runner.slurm_extra_args, None)
+
+    def test_fetch_slurm_runner_with_partition(self):
+        """fetch_runner returns a SlurmRunner with partition
+        """
+        runner = fetch_runner("SlurmRunner(partition=default)")
+        self.assertTrue(isinstance(runner, SlurmRunner))
+        self.assertEqual(runner.nslots, 1)
+        self.assertEqual(runner.partition, "default")
+        self.assertFalse(runner.join_logs)
+        self.assertEqual(runner.slurm_extra_args, None)
+
+    def test_fetch_slurm_runner_with_join_logs(self):
+        """fetch_runner returns a SlurmRunner with join_logs
+        """
+        runner = fetch_runner("SlurmRunner(join_logs=True)")
+        self.assertTrue(isinstance(runner, SlurmRunner))
+        self.assertEqual(runner.nslots, 1)
+        self.assertEqual(runner.partition, None)
+        self.assertTrue(runner.join_logs)
+        self.assertEqual(runner.slurm_extra_args, None)
+
+    def test_fetch_slurm_runner_with_extra_args(self):
+        """fetch_runner returns a SlurmRunner with additional arguments
+        """
+        # Extra args that set nslots and partition
+        runner = fetch_runner("SlurmRunner(-n 8 -p default)")
+        self.assertTrue(isinstance(runner, SlurmRunner))
+        self.assertEqual(runner.nslots, 8)
+        self.assertEqual(runner.partition, "default")
+        self.assertFalse(runner.join_logs)
+        self.assertEqual(runner.slurm_extra_args, None)
+        # Extra args plus join_logs
+        runner = fetch_runner("SlurmRunner(-n 8 -p default join_logs=y)")
+        self.assertTrue(isinstance(runner, SlurmRunner))
+        self.assertEqual(runner.nslots, 8)
+        self.assertEqual(runner.partition, "default")
+        self.assertTrue(runner.join_logs)
+        self.assertEqual(runner.slurm_extra_args, None)
+        # Arbitrary non-reserved extra args
+        runner = fetch_runner("SlurmRunner(-n 8 --mail-type=ALL --mail-user=emailaddr@manchester.ac.uk join_logs=n)")
+        self.assertTrue(isinstance(runner, SlurmRunner))
+        self.assertEqual(runner.nslots, 8)
+        self.assertEqual(runner.partition, None)
+        self.assertFalse(runner.join_logs)
+        self.assertEqual(runner.slurm_extra_args,
+                         ["--mail-type=ALL",
+                          "--mail-user=emailaddr@manchester.ac.uk"])
+
     def test_fetch_bad_runner_raises_exception(self):
         """fetch_runner raises exception for unknown runner
         """

--- a/bcftbx/test/test_JobRunner.py
+++ b/bcftbx/test/test_JobRunner.py
@@ -4,6 +4,8 @@
 from bcftbx.JobRunner import *
 from bcftbx.mockGE import setup_mock_GE
 from bcftbx.mockGE import MockGE
+from bcftbx.mockslurm import setup_mock_slurm
+from bcftbx.mockslurm import MockSlurm
 import bcftbx.utils
 import unittest
 import tempfile
@@ -551,6 +553,454 @@ class TestGEJobRunner(unittest.TestCase):
         # Create a runner with multiple nslots
         runner = GEJobRunner(ge_extra_args=['-pe','amd.pe','8'])
         self.assertEqual(runner.nslots,8)
+        jobid = self.run_job(runner,
+                             'test',
+                             self.working_dir,
+                             '/bin/bash',
+                             ('-c','echo $BCFTBX_RUNNER_NSLOTS',))
+        self.wait_for_jobs(runner,jobid)
+        with io.open(runner.logFile(jobid),'rt') as fp:
+            self.assertEqual(u"8\n",fp.read())
+
+class TestSlurmRunner(unittest.TestCase):
+
+    def setUp(self):
+        # Set up mockSLURM utilities
+        self.database_dir = self.make_tmp_dir()
+        self.bin_dir = self.make_tmp_dir()
+        self.old_path = os.environ['PATH']
+        os.environ['PATH'] = self.bin_dir + os.pathsep + self.old_path
+        setup_mock_slurm(bindir=self.bin_dir,
+                         database_dir=self.database_dir,
+                         sbatch_delay=0.4,
+                         debug=False)
+        self.mock_slurm = MockSlurm(database_dir=self.database_dir,
+                                    debug=True)
+        # Create a temporary directory to work in
+        self.working_dir = self.make_tmp_dir()
+        self.log_dir = None
+
+    def tearDown(self):
+        self.mock_slurm.stop()
+        os.environ['PATH'] = self.old_path
+        shutil.rmtree(self.database_dir)
+        shutil.rmtree(self.bin_dir)
+        shutil.rmtree(self.working_dir)
+        if self.log_dir is not None:
+            shutil.rmtree(self.log_dir)
+
+    def make_tmp_dir(self):
+        return tempfile.mkdtemp(dir=os.getcwd())
+
+    def update_jobs(self, timeout=1.0):
+        poll_interval = 0.1
+        ntries = 0
+        while (ntries*poll_interval < timeout):
+            time.sleep(poll_interval)
+            ntries += 1
+            self.mock_slurm.update_jobs()
+
+    def run_job(self,runner,*args):
+        try:
+            return runner.run(*args)
+        except OSError:
+            self.fail("Unable to run Slurm job")
+
+    def wait_for_jobs(self,runner,*args):
+        poll_interval = 0.1
+        timeout = 10.0
+        ntries = 0
+        running_jobs = True
+        # Check running jobs
+        while (ntries*poll_interval < timeout) and running_jobs:
+            self.mock_slurm.update_jobs()
+            running_jobs = False
+            for jobid in args:
+                if runner.isRunning(jobid):
+                    running_jobs = True
+            if running_jobs:
+                time.sleep(poll_interval)
+                ntries += 1
+        # All jobs finished
+        if not running_jobs:
+            return
+        # Otherwise we've reached the timeout limit
+        for jobid in args:
+            # Terminate jobs
+            if runner.isRunning(jobid):
+                runner.terminate(jobid)
+        self.fail("Timed out waiting for test job")
+
+    def test_slurm_runner_fast_command(self):
+        """
+        Test SlurmRunner with fast shell command
+        """
+        # Create a runner
+        runner = SlurmRunner()
+        self.assertEqual(runner.nslots, 1)
+        self.assertEqual(runner.partition, None)
+        self.assertFalse(runner.join_logs)
+        # Execute simple command
+        jobid = self.run_job(runner,
+                             "slurm_test",
+                             self.working_dir,
+                             'echo', ('this is a quick test',))
+        self.assertTrue(runner.isRunning(jobid))
+        self.wait_for_jobs(runner, jobid)
+        # Check outputs
+        self.assertEqual(runner.name(jobid), "slurm_test")
+        expected_log = os.path.join(self.working_dir, f"slurm_test.o{jobid}")
+        self.assertEqual(expected_log, runner.logFile(jobid))
+        self.assertTrue(os.path.isfile(runner.logFile(jobid)),
+                        "Stdout file '%s': not a file" %
+                        runner.logFile(jobid))
+        expected_err = os.path.join(self.working_dir, f"slurm_test.e{jobid}")
+        self.assertEqual(expected_err, runner.errFile(jobid))
+        self.assertTrue(os.path.isfile(runner.errFile(jobid)),
+                        "Stderr file '%s': not a file" %
+                        runner.errFile(jobid))
+        # Check exit status of completed job
+        self.assertEqual(runner.exit_status(jobid), 0)
+
+    def test_slurm_runner_fast_command_with_initial_delay(self):
+        """
+        Test SlurmRunner with fast shell command & initial delay
+        """
+        # Create a runner
+        runner = SlurmRunner()
+        self.assertEqual(runner.nslots, 1)
+        self.assertEqual(runner.partition, None)
+        self.assertFalse(runner.join_logs)
+        # Execute "echo" command
+        jobid = self.run_job(runner,
+                             "slurm_test",
+                             self.working_dir,
+                             "echo", ("this is a quick test",))
+        # Do some updates so the job finishes before the
+        # first check
+        self.update_jobs()
+        self.assertTrue(runner.isRunning(jobid))
+        self.wait_for_jobs(runner, jobid)
+        # Check outputs
+        self.assertEqual(runner.name(jobid), "slurm_test")
+        expected_log = os.path.join(self.working_dir, f"slurm_test.o{jobid}")
+        self.assertEqual(expected_log, runner.logFile(jobid))
+        self.assertTrue(os.path.isfile(runner.logFile(jobid)),
+                        "Stdout file '%s': not a file" %
+                        runner.errFile(jobid))
+        expected_err = os.path.join(self.working_dir, f"slurm_test.e{jobid}")
+        self.assertEqual(expected_err, runner.errFile(jobid))
+        self.assertTrue(os.path.isfile(runner.errFile(jobid)),
+                        "Stderr file '%s': not a file" %
+                        runner.errFile(jobid))
+        self.assertEqual(runner.exit_status(jobid),0)
+        # Check exit status of completed job
+        self.assertEqual(runner.exit_status(jobid), 0)
+
+    def test_slurm_runner_slow_command(self):
+        """
+        Test SlurmRunner with a slow shell command
+        """
+        # Create a runner
+        runner = SlurmRunner()
+        self.assertEqual(runner.nslots, 1)
+        self.assertEqual(runner.partition, None)
+        self.assertFalse(runner.join_logs)
+        # Execute sleep command
+        jobid = self.run_job(runner,
+                             "slurm_test",
+                             self.working_dir,
+                             'sleep', ('5',))
+        self.assertTrue(runner.isRunning(jobid))
+        self.wait_for_jobs(runner,jobid)
+        # Check outputs
+        self.assertEqual(runner.name(jobid),"slurm_test")
+        expected_log = os.path.join(self.working_dir, f"slurm_test.o{jobid}")
+        self.assertEqual(expected_log, runner.logFile(jobid))
+        self.assertTrue(os.path.isfile(runner.logFile(jobid)),
+                        "Stdout file '%s': not a file" %
+                        runner.logFile(jobid))
+        expected_err = os.path.join(self.working_dir, f"slurm_test.e{jobid}")
+        self.assertEqual(expected_err, runner.errFile(jobid))
+        self.assertTrue(os.path.isfile(runner.errFile(jobid)),
+                        "Stderr file '%s': not a file" %
+                        runner.errFile(jobid))
+        # Check exit status of completed job
+        self.assertEqual(runner.exit_status(jobid), 0)
+
+    def test_slurm_runner_exit_status(self):
+        """
+        Test SlurmRunner returns correct exit status
+        """
+        # Create a runner
+        runner = SlurmRunner()
+        self.assertEqual(runner.nslots, 1)
+        self.assertEqual(runner.partition, None)
+        self.assertFalse(runner.join_logs)
+        # Execute commands with known exit codes
+        jobid_ok = self.run_job(runner,
+                                "slurm_ok",
+                                self.working_dir,
+                                '/bin/bash', ('-c','exit 0',))
+        self.assertTrue(runner.isRunning(jobid_ok))
+        jobid_error = self.run_job(runner,
+                                   "slurm_error",
+                                   self.working_dir,
+                                   '/bin/bash', ('-c','exit 1',))
+        self.assertTrue(runner.isRunning(jobid_error))
+        self.wait_for_jobs(runner,jobid_ok,jobid_error)
+        # Check exit codes
+        self.assertEqual(runner.exit_status(jobid_ok), 0)
+        self.assertEqual(runner.exit_status(jobid_error), 1)
+
+    def test_slurm_runner_termination(self):
+        """
+        Test SlurmRunner can terminate a running job
+        """
+        # Create a runner
+        runner = SlurmRunner()
+        # Execute sleep command
+        jobid = self.run_job(runner,
+                             "slurm_test",
+                             self.working_dir,
+                             'sleep', ('60s',))
+        # Wait for job to start
+        ntries = 0
+        while ntries < 100:
+            if runner.isRunning(jobid):
+                break
+            ntries += 1
+        self.assertTrue(runner.isRunning(jobid))
+        # Terminate job before it completes
+        runner.terminate(jobid)
+        self.update_jobs()
+        self.assertFalse(runner.isRunning(jobid))
+        self.assertNotEqual(runner.exit_status(jobid), 0)
+
+    def test_slurm_runner_join_logs(self):
+        """
+        Test SlurmRunner with 'join_logs'
+        """
+        # Create a runner with join_logs set
+        runner = SlurmRunner(join_logs=True)
+        self.assertTrue(runner.join_logs)
+        # Execute the echo command
+        jobid = self.run_job(runner,
+                             "slurm_test",
+                             self.working_dir,
+                             'echo', ('this is a test',))
+        self.wait_for_jobs(runner, jobid)
+        # Check log and err files are the same
+        self.assertEqual(runner.name(jobid), "slurm_test")
+        expected_log = os.path.join(self.working_dir, f"slurm_test.o{jobid}")
+        self.assertEqual(expected_log, runner.logFile(jobid))
+        self.assertTrue(os.path.isfile(runner.logFile(jobid)),
+                        "Stdout file '%s': not a file" %
+                        runner.logFile(jobid))
+        self.assertEqual(runner.logFile(jobid), runner.errFile(jobid))
+        # Check exit status of completed job
+        self.assertEqual(runner.exit_status(jobid), 0)
+
+    def test_slurm_runner_extra_args_sets_nslots(self):
+        """
+        Test SlurmRunner extra arguments: '-n' implicitly sets nslots
+        """
+        runner = SlurmRunner(slurm_extra_args=("-n", "8"))
+        self.assertEqual(runner.nslots, 8)
+        self.assertEqual(runner.slurm_extra_args, None)
+        # Exception if try to set it twice
+        self.assertRaises(Exception,
+                          SlurmRunner,
+                          nslots=8,
+                          slurm_extra_args=("-n", "8"))
+
+    def test_slurm_runner_extra_args_sets_partition(self):
+        """
+        Test SlurmRunner extra arguments: '-p' implicitly sets partition
+        """
+        runner = SlurmRunner(slurm_extra_args=("-p", "default"))
+        self.assertEqual(runner.partition, "default")
+        self.assertEqual(runner.slurm_extra_args, None)
+        # Exception if try to set it twice
+        self.assertRaises(Exception,
+                          SlurmRunner,
+                          partition="default",
+                          slurm_extra_args=("-p", "default"))
+
+    def test_slurm_runner_extra_args_doesnt_allow_setting_log_files(self):
+        """
+        Test SlurmRunner extra arguments: '-o' and '-e' not allowed
+        """
+        self.assertRaises(Exception,
+                          SlurmRunner,
+                          slurm_extra_args=("-o", "slurm-%j.out"))
+        self.assertRaises(Exception,
+                          SlurmRunner,
+                          slurm_extra_args=("-e",
+                                            "slurm-%j.err",
+                                            "-o",
+                                            "slurm-%j.out"))
+
+    def test_slurm_runner_extra_args_doesnt_allow_setting_export(self):
+        """
+        Test SlurmRunner extra arguments: '--export' not allowed
+        """
+        self.assertRaises(Exception,
+                          SlurmRunner,
+                          slurm_extra_args=("--export", "ALL"))
+        self.assertRaises(Exception,
+                          SlurmRunner,
+                          slurm_extra_args=("--export=ALL",))
+
+    def test_slurm_runner_extra_args_preserves_unreserved_options(self):
+        """
+        Test SlurmRunner extra arguments: preserves unreserved options
+        """
+        runner = SlurmRunner(slurm_extra_args=("-n", "8", "-l"))
+        self.assertEqual(runner.nslots, 8)
+        self.assertEqual(runner.slurm_extra_args, ["-l"])
+
+    def test_slurm_runner_set_log_dir(self):
+        """
+        Test SlurmRunner explicitly setting log directory
+        """
+        # Create a temporary log directory
+        self.log_dir = self.make_tmp_dir()
+        # Create a runner with custom log directory
+        runner = SlurmRunner(log_dir=self.log_dir)
+        self.assertEqual(runner.log_dir, self.log_dir)
+        # Execute the echo command
+        jobid = self.run_job(runner,
+                             "slurm_test",
+                             self.working_dir,
+                             'echo', ('this is a test',))
+        self.wait_for_jobs(runner, jobid)
+        # Check outputs
+        self.assertEqual(runner.name(jobid), "slurm_test")
+        expected_log = os.path.join(self.log_dir, f"slurm_test.o{jobid}")
+        self.assertEqual(expected_log, runner.logFile(jobid))
+        self.assertTrue(os.path.isfile(runner.logFile(jobid)),
+                        "Stdout file '%s': not a file" %
+                        runner.logFile(jobid))
+        expected_err = os.path.join(self.log_dir, f"slurm_test.e{jobid}")
+        self.assertEqual(expected_err, runner.errFile(jobid))
+        self.assertTrue(os.path.isfile(runner.errFile(jobid)),
+                        "Stderr file '%s': not a file" %
+                        runner.errFile(jobid))
+
+    def test_slurm_runner_set_log_dir_multiple_times(self):
+        """
+        Test SlurmRunner explicitly setting log directory multiple times
+        """
+        # Create a temporary log directory
+        self.log_dir = self.make_tmp_dir()
+        # Create a runner with custom log directory
+        runner = SlurmRunner(log_dir=self.log_dir)
+        self.assertEqual(runner.log_dir, self.log_dir)
+        # Execute the echo command
+        jobid1 = self.run_job(runner,
+                              "slurm_test1",
+                              self.working_dir,
+                              'echo', ('this is a test',))
+        # Reset the log directory and run second job
+        runner.set_log_dir(self.working_dir)
+        jobid2 = self.run_job(runner,
+                              "slurm_test2",
+                              self.working_dir,
+                              'echo', ('this is a test',))
+        # Reset the log directory again and run 3rd job
+        runner.set_log_dir(self.log_dir)
+        jobid3 = self.run_job(runner,
+                              "slurm_test3",
+                              self.working_dir,
+                              'echo',('this is a test',))
+        self.wait_for_jobs(runner, jobid1, jobid2, jobid3)
+        # Check outputs for job #1
+        self.assertEqual(runner.name(jobid1), "slurm_test1")
+        expected_log = os.path.join(self.log_dir, f"slurm_test1.o{jobid1}")
+        self.assertEqual(expected_log, runner.logFile(jobid1))
+        self.assertTrue(os.path.isfile(runner.logFile(jobid1)),
+                        "Stdout file '%s': not a file" %
+                        runner.logFile(jobid1))
+        expected_err = os.path.join(self.log_dir, f"slurm_test1.e{jobid1}")
+        self.assertEqual(expected_err, runner.errFile(jobid1))
+        self.assertTrue(os.path.isfile(runner.errFile(jobid1)),
+                        "Stderr file '%s': not a file" %
+                        runner.errFile(jobid1))
+        # Check outputs for job #2
+        self.assertEqual(runner.name(jobid2), "slurm_test2")
+        expected_log = os.path.join(self.working_dir, f"slurm_test2.o{jobid2}")
+        self.assertEqual(expected_log, runner.logFile(jobid2))
+        self.assertTrue(os.path.isfile(runner.logFile(jobid2)),
+                        "Stdout file '%s': not a file" %
+                        runner.logFile(jobid2))
+        expected_err = os.path.join(self.working_dir, f"slurm_test2.e{jobid2}")
+        self.assertEqual(expected_err, runner.errFile(jobid2))
+        self.assertTrue(os.path.isfile(runner.errFile(jobid2)),
+                        "Stderr file '%s': not a file" %
+                        runner.errFile(jobid2))
+        # Check outputs for job #3
+        self.assertEqual(runner.name(jobid3), "slurm_test3")
+        expected_log = os.path.join(self.log_dir, f"slurm_test3.o{jobid3}")
+        self.assertEqual(expected_log, runner.logFile(jobid3))
+        self.assertTrue(os.path.isfile(runner.logFile(jobid3)),
+                        "Stdout file '%s': not a file" %
+                        runner.logFile(jobid3))
+        expected_err = os.path.join(self.log_dir, f"slurm_test3.e{jobid3}")
+        self.assertEqual(expected_err, runner.errFile(jobid3))
+        self.assertTrue(os.path.isfile(runner.errFile(jobid3)),
+                        "Stderr file '%s': not a file" %
+                        runner.errFile(jobid3))
+
+    @unittest.skip("don't know what error state looks like for Slurm")
+    def test_slurm_runner_error_state(self):
+        """
+        Test SlurmRunner detects job in error state
+        """
+        # Create a runner and execute a command in a non-existent
+        # working directory
+        runner = SlurmRunner(slurm_extra_args=self.slurm_extra_args)
+        jobid = self.run_job(runner,'test_eqw',
+                             '/non/existent/dir',
+                             'echo', ('this should fail',))
+        # Wait for job to go into error state
+        ntries = 0
+        while ntries < 100:
+            if runner.errorState(jobid):
+                # Success - job errored
+                return
+            time.sleep(0.1)
+            ntries += 1
+        self.fail("Job failed to go into error state")
+
+    def test_slurm_runner_repr(self):
+        """
+        Test SlurmRunner __repr__ method
+        """
+        self.assertEqual("SlurmRunner", str(SlurmRunner()))
+        self.assertEqual("SlurmRunner(nslots=8)",
+                         str(SlurmRunner(nslots=8)))
+        self.assertEqual("SlurmRunner(join_logs=True)",
+                         str(SlurmRunner(join_logs=True)))
+
+    def test_slurm_runner_nslots(self):
+        """
+        Test SlurmRunner sets BCFTBX_RUNNER_NSLOTS
+        """
+        # Create a runner and check default nslots
+        runner = SlurmRunner()
+        self.assertEqual(runner.nslots, 1)
+        jobid = self.run_job(runner,
+                             'test',
+                             self.working_dir,
+                             '/bin/bash',
+                             ('-c','echo $BCFTBX_RUNNER_NSLOTS',))
+        self.wait_for_jobs(runner,jobid)
+        with io.open(runner.logFile(jobid),'rt') as fp:
+            self.assertEqual(u"1\n",fp.read())
+        # Create a runner with multiple nslots
+        runner = SlurmRunner(nslots=8)
+        self.assertEqual(runner.nslots, 8)
         jobid = self.run_job(runner,
                              'test',
                              self.working_dir,


### PR DESCRIPTION
Implements a new job runner `SlurmRunner` in `bcftbx/JobRunner.py` which should enable the use of Slurm as a job submission engine.

Useful resources:

* https://slurm.schedmd.com/sbatch.html (Slurm `sbatch` documentation)
* https://docs.hpc.shef.ac.uk/en/latest/hpc/scheduler/#gsc.tab=0 (Slurm on Sheffield Uni HPC)
* https://ri.itservices.manchester.ac.uk/csf4/batch/sge-to-slurm/ (UoM CSF4 SGE-to-SLURM conversion)

This is a work-in-progress.