### PR TITLE
Add 'sphinx' section to ReadTheDocs YAML to explicitly specify 'conf.py' location

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,3 +15,6 @@ python:
     - requirements: docs/requirements.txt
     - method: pip
       path: .
+
+sphinx:
+  configuration: docs/source/conf.py


### PR DESCRIPTION
Fixes bug with building the documentation on ReadTheDocs, following this update:

https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

Specifically the .readthedocs.yaml file now needs the location of the Sphinx conf.py file to be explicitly specified, otherwise the build will fail.