### PR TITLE
Replace defunct 'ubuntu-20.04' runner for CI tests & update Python versions

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -8,9 +8,7 @@ on: [ push, pull_request ]
 jobs:
   build:
 
-    # Switched from ubuntu-latest to ubuntu-20.04 as former
-    # doesn't support Python 3.6
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -14,6 +14,8 @@ following versions are supported:
 * Python 3.8
 * Python 3.9
 * Python 3.10
+* Python 3.11
+* Python 3.12
 
 Older Python 3 versions may also still work but are no longer included
 in the automated tests.

--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -11,11 +11,12 @@ Supported Python versions
 The package consists predominantly of code written in Python, and the
 following versions are supported:
 
-* Python 3.6
-* Python 3.7
 * Python 3.8
 * Python 3.9
 * Python 3.10
+
+Older Python 3 versions may also still work but are no longer included
+in the automated tests.
 
 .. _software_dependencies:
 


### PR DESCRIPTION
Updates the workflow for the CI testing via GitHub Actions, to replace the ubuntu-20.04 hosted runner (which closes down in April 2025) with the ubuntu-24.04 runner.