### PR TITLE
bcftbx/FASTQFile: update 'SequenceIdentifier' to handle R3 reads

### DIFF
--- a/bcftbx/FASTQFile.py
+++ b/bcftbx/FASTQFile.py
@@ -1,5 +1,5 @@
 #     FASTQFile.py: read and manipulate FASTQ files and data
-#     Copyright (C) University of Manchester 2012-2020 Peter Briggs
+#     Copyright (C) University of Manchester 2012-2025 Peter Briggs
 #
 ########################################################################
 #
@@ -46,7 +46,7 @@ import itertools
 
 # Match Illumina 1.8+ format, e.g.:
 # @EAS139:136:FC706VJ:2:2104:15343:197393 1:Y:18:ATCACG
-RE_ILLUMINA18 = re.compile(r"^@([^:]+):([0-9]+):([^:]+):([0-9]+):([0-9]+):([0-9]+):([0-9]+) (1|2):(Y|N):([0-9]+):(.*)$")
+RE_ILLUMINA18 = re.compile(r"^@([^:]+):([0-9]+):([^:]+):([0-9]+):([0-9]+):([0-9]+):([0-9]+) (1|2|3):(Y|N):([0-9]+):(.*)$")
 #
 # Match  earlier Illumina format (1.3/1.5), e.g.:
 # @HWUSI-EAS100R:6:73:941:1973#0/1

--- a/bcftbx/test/test_FASTQFile.py
+++ b/bcftbx/test/test_FASTQFile.py
@@ -377,6 +377,16 @@ class TestSequenceIdentifier(unittest.TestCase):
         self.assertFalse(SequenceIdentifier(seqid1).is_pair_of(SequenceIdentifier(seqid1)))
         self.assertFalse(SequenceIdentifier(seqid3).is_pair_of(SequenceIdentifier(seqid1)))
 
+    def test_handle_r1_r2_r3_pair_id(self):
+        """Check that R1/R2/R3 sequence identifiers have correct pair ID
+        """
+        seqid1 = "@HWI-700511R:183:D2C8UACXX:1:1101:1115:2123 1:N:0:GCCAAT"
+        seqid2 = "@HWI-700511R:183:D2C8UACXX:1:1101:1115:2123 2:N:0:GCCAAT"
+        seqid3 = "@HWI-700511R:183:D2C8UACXX:1:1101:1115:2123 3:N:0:GCCAAT"
+        self.assertEqual(SequenceIdentifier(seqid1).pair_id, "1")
+        self.assertEqual(SequenceIdentifier(seqid2).pair_id, "2")
+        self.assertEqual(SequenceIdentifier(seqid3).pair_id, "3")
+
 class TestFastqAttributes(unittest.TestCase):
     """Tests of the FastqAttributes class
     """


### PR DESCRIPTION
Updates the `SequenceIdentifier` class in `FASTQFile` so it can handle headers from R3 reads (i.e. where `pair_id` is 3), e.g.

    @HWI-700511R:183:D2C8UACXX:1:1101:1115:2123 3:N:0:GCCAAT

Previously this would result in none of the data being read from read header.