### PR TITLE
Fix highest version of 'Xlsxwriter' for Python 3.6 & 3.7 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 xlwt>=0.7.2
 xlrd>=0.7.1
 xlutils>=1.4.1
-xlsxwriter>=0.8.4
+xlsxwriter>=0.8.4,<=3.2.2

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(name = "genomics-bcftbx",
       install_requires = ['xlwt >= 0.7.2',
                           'xlrd >= 0.7.1',
                           'xlutils >= 1.4.1',
-                          'xlsxwriter >= 0.8.4',],
+                          'xlsxwriter >= 0.8.4, <= 3.2.2',],
       # Enable 'python setup.py test'
       test_suite='nose.collector',
       tests_require=['nose'],


### PR DESCRIPTION
Updates `setup.py` and `requirements.txt` to limit the highest version of the external `Xlsxwriter` package to 3.2.2 (the last one which still supports Python 3.6 and 3.7 - subsequent version dropped support https://xlsxwriter.readthedocs.io/changes.html#release-3-2-3-april-17-2025).