### PR TITLE
Add CONTRIBUTING file to repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributor guidelines
+
+The `genomics-bcftbx` package has been developed specifically for use within the Bioinformatics
+Core Facility at the University of Manchester, and is currently maintained by a single software
+developer with limited time and resources.
+
+As a result, while contributions are welcome, it may take some time before they are reviewed, and
+bugs and feature requests which don't directly impact on our core facility's operations will
+necessarily be treated as a lower priority than those which do.
+
+We ask that you please be patient if your contribution is not addressed immediately, or if it's
+rejected: neither of these should be seen as a reflection on the quality or value of your
+contribution, or its importance to you.
+
+If you still wish to contribute, please read the guidelines below for more information on how to do
+so.
+
+## Did you find a bug?
+
+Before reporting a bug, please check whether it has already been reported by searching the
+[GitHub issue tracker](https://github.com/fls-bioinformatics-core/genomics/issues).
+
+If you're unable to find an open issue addressing the problem then you can
+[open a new one](https://github.com/fls-bioinformatics-core/genomics/issues/new).
+
+Please be sure to include **a title and a clear description** of the problem, with as much
+relevant information as possible (for example, describing the commands or code that you ran,
+the expected outcome, and the actual behaviour you observed along with any error messages).
+
+Essentially the more chance we have of reproducing your problem, the more likely it is that
+we'll be able to solve it.
+
+## Have you written a patch that fixes a bug?
+
+Please open a new GitHub pull request with a patch:
+
+* Fork the repository and create a new branch for your patch
+* Make your changes
+* Ensure that any existing tests pass, and add new tests if appropriate
+* Update the relevant documentation if appropriate
+* Submit a pull request describing your changes
+
+Please ensure the pull request description clearly describes the problem and solution, and include
+the relevant issue number if applicable.
+
+Examples of current and closed pull requests can be found via the
+[GitHub pull request list](https://github.com/fls-bioinformatics-core/genomics/pulls).
+
+## Do you want to suggest a new feature or enhancement?
+
+Suggestions for new features or enhancements can be made by opening a new issue on the
+[GitHub issue tracker](https://github.com/fls-bioinformatics-core/genomics/issues).
+Please provide as much detail as possible about the feature you are suggesting, including the
+problem it aims to solve and any potential implementation ideas you may have.
+
+Alternatively, if you have already implemented the feature as a patch, please submit it as a
+pull request as described above.
+
+Please note however that unfortunately feature requests which do not directly impact on the
+operations of the core facility are unlikely to be prioritised for implementation.
+
+## Do you want to improve the documentation?
+
+Contributions to the documentation are very welcome! If you have found an error, or think
+something could be explained more clearly, please either create a new issue on the issue tracker
+or submit a pull request with your proposed changes, as described above.
+
+## What kinds of contributions are unlikely to be accepted?
+
+Sorry - changes that are cosmetic in nature (for example, fixes to whitespace or reformatting
+of code) and do not add anything substantial to the functionality of the `bcftbx` package are
+likely to be rejected without further consideration.
+
+**Thanks for your interest in the project!**

--- a/README.rst
+++ b/README.rst
@@ -102,3 +102,9 @@ installed using:
 ::
 
     pip install git+https://github.com/fls-bioinformatics-core/genomics.git@devel
+
+Contributing
+************
+
+See `CONTRIBUTING.md <CONTRIBUTING.md>`_ file for guidelines on how to
+contribute to the project.


### PR DESCRIPTION
Adds a CONTRIBUTING.md file to explain how to contribute to the project (e.g. bug reports, patches etc).

See GitHub documentation on setting contribution guidelines: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors