### PR TITLE
Refactor 'FASTQFile' into new 'io.fastq' module

### DIFF
--- a/bcftbx/FASTQFile.py
+++ b/bcftbx/FASTQFile.py
@@ -1,5 +1,5 @@
 #     FASTQFile.py: read and manipulate FASTQ files and data
-#     Copyright (C) University of Manchester 2012-2025 Peter Briggs
+#     Copyright (C) University of Manchester 2012-2026 Peter Briggs
 #
 ########################################################################
 #
@@ -8,144 +8,75 @@
 #########################################################################
 
 """
-A set of classes for reading through FASTQ files and manipulating
-the data within them:
+Legacy module providing a set of classes for reading through FASTQ files
+and manipulating the data within them.
+
+The core functionality has been reimplemented in the ``io.fastq`` module;
+the classes and functions in this module are now deprecated and only
+maintained for backwards compatibility; they will be removed in a future
+release.
+
+The legacy classes and functions are:
 
 * FastqIterator: enables looping through all read records in FASTQ file
 * FastqRead: provides access to a single FASTQ read record
 * SequenceIdentifier: provides access to sequence identifier info in a read
 * FastqAttributes: provides access to gross attributes of FASTQ file
-
-Additionally there are a few utility functions:
-
 * get_fastq_file_handle: return a file handled opened for reading a FASTQ file
 * nreads: return the number of reads in a FASTQ file
 * fastqs_are_pair: check whether two FASTQs form an R1/R2 pair
 
-Information on the FASTQ file format: http://en.wikipedia.org/wiki/FASTQ_format
+.. note::
 
+   The ``FastqAttributes`` class has not been reimplemented in
+   ``io.fastq``; it should no longer be used.
 """
-
-CHUNKSIZE = 102400
 
 #######################################################################
 # Import modules that this module depends on
 #######################################################################
 
-from collections.abc import Iterator
+
 import os
-import io
-import re
-import logging
-import gzip
-import itertools
+from .io.fastq import FastqIterator as _FastqIterator
+from .io.fastq import FastqRead as _FastqRead
+from .io.fastq import SequenceIdentifier as _SequenceIdentifier
+from .io.fastq import get_fastq_file_handle
+from .io.fastq import count_reads as nreads
+from .io.fastq import fastqs_are_pair
 
-#######################################################################
-# Precompiled regular expressions
-#######################################################################
-
-# Match Illumina 1.8+ format, e.g.:
-# @EAS139:136:FC706VJ:2:2104:15343:197393 1:Y:18:ATCACG
-RE_ILLUMINA18 = re.compile(r"^@([^:]+):([0-9]+):([^:]+):([0-9]+):([0-9]+):([0-9]+):([0-9]+) (1|2|3):(Y|N):([0-9]+):(.*)$")
-#
-# Match  earlier Illumina format (1.3/1.5), e.g.:
-# @HWUSI-EAS100R:6:73:941:1973#0/1
-RE_ILLUMINA = re.compile(r"^@([^:]+):([0-9]+):([0-9]+):([0-9]+):([0-9]+)#([0-9]+)/(1|2)$")
 
 #######################################################################
 # Class definitions
 #######################################################################
 
-class FastqIterator(Iterator):
-    """FastqIterator
 
-    Class to loop over all records in a FASTQ file, returning a FastqRead
-    object for each record.
-
-    Example looping over all reads:
-
-    >>> for read in FastqIterator(fastq_file):
-    >>>    print(read)
-
-    Input FASTQ can be in gzipped format; FASTQ data can also be supplied
-    as a file-like object opened for reading, for example:
-
-    >>> fp = io.open(fastq_file,'rt')
-    >>> for read in FastqIterator(fp=fp):
-    >>>    print(read)
-    >>> fp.close()
-
+class FastqIterator(_FastqIterator):
     """
+    Iterator for looping over all records in a FASTQ file.
 
-    def __init__(self,fastq_file=None,fp=None,bufsize=CHUNKSIZE):
-        """Create a new FastqIterator
+    Deprecated legacy class: use ``FastqIterator`` from ``io.fastq``
+    instead.
 
-        The input FASTQ can be either a text file or a compressed (gzipped)
-        FASTQ, specified via a file name (using the 'fastq' argument), or a
-        file-like object opened for line reading (using the 'fp' argument).
+    Arguments:
+        fastq_file (str): name of the FASTQ file to iterate through
+        fp (any): file-like object opened for reading
+        bufsize (int): optional integer specifying number of bytes to
+            read as a single 'chunk' from disk
+    """
+    def __init__(self, fastq_file=None, fp=None, bufsize=None):
+        _FastqIterator.__init__(self, fastq_file=fastq_file, fp=fp, bufsize=bufsize)
 
-        Args:
-           fastq_file: name of the FASTQ file to iterate through
-           fp: file-like object opened for reading
-           bufsize: optional; integer specifying number of bytes to
-             read as a single 'chunk' from disk
-
-        """
-        self.__fastq_file = fastq_file
-        self.__bufsize = bufsize
-        if fp is None:
-            self.__fp = get_fastq_file_handle(self.__fastq_file,'rt')
-        else:
-            self.__fp = fp
-        self._buf = ''
-        self._lines = []
-        self._ip = 0
-
-    def __next__(self):
-        """Return next record from FASTQ file as a FastqRead object
-        """
-        # Convenience variables
-        lines = self._lines
-        buf = self._buf
-        ip = self._ip
-        bufsize = self.__bufsize
-        # Do we already have a read to return?
-        while len(lines) < 4:
-            # Fetch more data
-            data = self.__fp.read(bufsize)
-            if not data:
-                # Reached EOF
-                if self.__fastq_file is not None:
-                    self.__fp.close()
-                raise StopIteration
-            # Add to buffer and split into lines
-            buf = buf + data
-            if buf[-1] != '\n':
-                i = buf.rfind('\n')
-                if i == -1:
-                    continue
-                else:
-                    lines.extend(buf[:i].split('\n'))
-                    buf = buf[i+1:]
-            else:
-                lines.extend(buf[:-1].split('\n'))
-                buf = ''
-        # Return a read
-        read = lines[ip:ip + 4]
-        ip = ip + 4
-        if (len(lines) - ip) < 4:
-            # Not enough lines for another read so
-            # reset the buffer
-            lines = lines[ip:]
-            ip = 0
-        # Update internals
-        self._lines = lines
-        self._buf = buf
-        self._ip = ip
+    def _fastq_read(self, read):
         return FastqRead(*read)
 
-class FastqRead:
-    """Class to store a FASTQ record with information about a read
+
+class FastqRead(_FastqRead):
+    """
+    Class to store a FASTQ record with information about a read
+
+    Deprecated legacy class: use ``FastqRead`` from ``io.fastq``
+    instead.
 
     Provides the following properties for accessing the read data:
 
@@ -165,239 +96,65 @@ class FastqRead:
     - minquality: minimum quality value (in character representation)
     - is_colorspace: returns True if the read looks like a colorspace
       read, False otherwise
-
-    .. note::
-
-       Quality scores can only be obtained from character
-       representations once the encoding scheme is known.
-
     """
-
     def __init__(self,seqid_line=None,seq_line=None,optid_line=None,quality_line=None):
-        """Create a new FastqRead object
-
-        Arguments:
-          seqid_line: first line of the read record
-          sequence: second line of the record
-          optid: third line of the record
-          quality: fourth line of the record
-        """
-        self.raw_seqid = seqid_line
-        self.sequence = str(seq_line).rstrip()
-        self.optid = str(optid_line).rstrip()
-        self.quality = str(quality_line).rstrip()
+        _FastqRead.__init__(self, header=seqid_line, sequence=seq_line, optid=optid_line,
+                            quality=quality_line)
 
     @property
     def seqid(self):
-        try:
-            return self._seqid
-        except AttributeError:
-            self._seqid = SequenceIdentifier(self.raw_seqid)
-            return self._seqid
+        return self.header
+
+    @property
+    def raw_seqid(self):
+        return self.raw_header
 
     @property
     def seqlen(self):
-        try:
-            return self._seqlen
-        except AttributeError:
-            if self.is_colorspace:
-                self._seqlen = len(self.sequence) - 1
-            else:
-                self._seqlen = len(self.sequence)
-            return self._seqlen
+        return len(self)
 
     @property
     def maxquality(self):
-        try:
-            # Cached value
-            return self._maxqual
-        except AttributeError:
-            # Compute, store and return
-            if self.quality:
-                self._maxqual = max(self.quality)
-            else:
-                self._maxqual = ''
-        return self._maxqual
+        return self.max_quality
 
     @property
     def minquality(self):
-        try:
-            # Cached value
-            return self._minqual
-        except AttributeError:
-            # Compute, store and return
-            if self.quality:
-                self._minqual = min(self.quality)
-            else:
-                self._minqual = ''
-        return self._minqual
+        return self.min_quality
 
-    @property
-    def is_colorspace(self):
-        try:
-            return self._is_colorspace
-        except AttributeError:
-            pass
-        if self.seqid.format is None:
-            # Check if it looks like colorspace
-            # Sequence starts with 'T' and only contains characters
-            # 0-3 or '.'
-            sequence = self.sequence
-            if sequence.startswith('T'):
-                for c in sequence[1:]:
-                    if c not in '.0123':
-                        self._is_colorspace = False
-                        return self._is_colorspace
-                # Passed colorspace tests
-                self._is_colorspace = True
-                return self._is_colorspace
-        # Not colorspace
-        self._is_colorspace = False
-        return self._is_colorspace
+    def _sequencer_identifier(self, fastq_header):
+        # Internal, use this to an instance of the appropriate class
+        # Subclasses should override this if they're using a
+        # different class
+        return SequenceIdentifier(fastq_header)
 
-    def __repr__(self):
-        return '\n'.join((str(self.seqid),
-                          self.sequence,
-                          self.optid,
-                          self.quality))
 
-    def __eq__(self,other):
-        return (str(self) == str(other))
+class SequenceIdentifier(_SequenceIdentifier):
+    """
+    Class to store/manipulate sequence identifier information from a FASTQ record
 
-class SequenceIdentifier:
-    """Class to store/manipulate sequence identifier information from a FASTQ record
+    Deprecated legacy class: use ``SequenceIdentifier`` from ``io.fastq``
+    instead.
 
     Provides access to the data items in the sequence identifier line of a FASTQ
     record.
     """
 
     def __init__(self,seqid):
-        """Create a new SequenceIdentifier object
+        _SequenceIdentifier.__init__(self, fastq_header=seqid)
 
-        Arguments:
-          seqid: the sequence identifier line (i.e. first line) from the
-            FASTQ read record
-        """
-        # Initialise
-        self.__seqid = str(seqid).rstrip()
-        self.instrument_name = None
-        self.run_id = None
-        self.flowcell_id = None
-        self.flowcell_lane = None
-        self.tile_no = None
-        self.x_coord = None
-        self.y_coord = None
-        self.multiplex_index_no = None
-        self.pair_id =  None
-        self.bad_read = None
-        self.control_bit_flag = None
-        self.index_sequence = None
-        self._format = None
-        # Identify sequence id line elements
-        m = RE_ILLUMINA18.match(self.__seqid)
-        if m:
-            # example of Illumina 1.8+ format:
-            # @EAS139:136:FC706VJ:2:2104:15343:197393 1:Y:18:ATCACG
-            self._format = 'illumina18'
-            self.instrument_name = m.group(1)
-            self.run_id = m.group(2)
-            self.flowcell_id = m.group(3)
-            self.flowcell_lane = m.group(4)
-            self.tile_no = m.group(5)
-            self.x_coord = m.group(6)
-            self.y_coord = m.group(7)
-            self.pair_id = m.group(8)
-            self.bad_read = m.group(9)
-            self.control_bit_flag = m.group(10)
-            self.index_sequence = m.group(11)
-        else:
-            # Example of earlier Illumina format (1.3/1.5):
-            # @HWUSI-EAS100R:6:73:941:1973#0/1
-            m = RE_ILLUMINA.match(self.__seqid)
-            if m:
-                self._format = 'illumina'
-                self.instrument_name = m.group(1)
-                self.flowcell_lane = m.group(2)
-                self.tile_no = m.group(3)
-                self.x_coord = m.group(4)
-                self.y_coord = m.group(5)
-                self.multiplex_index_no = m.group(6)
-                self.pair_id = m.group(7)
-
-    @property
-    def format(self):
-        """
-        Identify the format of the sequence identifier
-
-        Returns:
-          String: 'illumina18', 'illumina' or None
-
-        """
-        try:
-            return self._format
-        except AttributeError:
-            pass
-
-    def is_pair_of(self,seqid):
-        """Check if this forms a pair with another SequenceIdentifier
-
-        """
-        # Check we have r1/r2
-        read_indices = [int(self.pair_id),int(seqid.pair_id)]
-        read_indices.sort()
-        if read_indices != [1,2]:
-            return False
-        # Check all other attributes match
-        try:
-            return (self.instrument_name  == seqid.instrument_name and
-                    self.run_id           == seqid.run_id and
-                    self.flowcell_id      == seqid.flowcell_id and
-                    self.flowcell_lane    == seqid.flowcell_lane and
-                    self.tile_no          == seqid.tile_no and
-                    self.x_coord          == seqid.x_coord and
-                    self.y_coord          == seqid.y_coord and
-                    self.multiplex_index_no == seqid.multiplex_index_no and
-                    self.bad_read         == seqid.bad_read and
-                    self.control_bit_flag == seqid.control_bit_flag and
-                    self.index_sequence   == seqid.index_sequence)
-        except Exception:
-            return False
-        
-    def __repr__(self):
-        if self.format == 'illumina18':
-            return "@%s:%s:%s:%s:%s:%s:%s %s:%s:%s:%s" % (self.instrument_name, 
-                                                          self.run_id,
-                                                          self.flowcell_id,
-                                                          self.flowcell_lane,
-                                                          self.tile_no,
-                                                          self.x_coord,
-                                                          self.y_coord,
-                                                          self.pair_id,
-                                                          self.bad_read,
-                                                          self.control_bit_flag,
-                                                          self.index_sequence)
-        elif self.format == 'illumina':
-            return "@%s:%s:%s:%s:%s#%s/%s" % (self.instrument_name,
-                                              self.flowcell_lane,
-                                              self.tile_no,
-                                              self.x_coord,
-                                              self.y_coord,
-                                              self.multiplex_index_no,
-                                              self.pair_id)
-        else:
-            # Return what was put in
-            return self.__seqid
 
 class FastqAttributes:
-    """Class to provide access to gross attributes of a FASTQ file
+    """
+    Class to provide access to gross attributes of a FASTQ file
+
+    Deprecated legacy class; do not use as it will be removed in
+    a future release.
 
     Given a FASTQ file (can be uncompressed or gzipped), enables
     various attributes to be queried via the following properties:
 
     nreads: number of reads in the FASTQ file
     fsize:  size of the file (in bytes)
-    
-
     """
     def __init__(self,fastq_file=None,fp=None):
         """Create a new FastqAttributes object
@@ -429,97 +186,3 @@ class FastqAttributes:
         
         """
         return os.path.getsize(self.__fastq_file)
-
-#######################################################################
-# Functions
-#######################################################################
-
-def get_fastq_file_handle(fastq,mode='rt'):
-    """Return a file handle opened for reading for a FASTQ file
-
-    Deals with both compressed (gzipped) and uncompressed FASTQ
-    files.
-
-    Arguments:
-      fastq: name (including path, if required) of FASTQ file.
-        The file can be gzipped (must have '.gz' extension)
-      mode: optional mode for file opening (defaults to 'rt')
-
-    Returns:
-      File handle that can be used for read operations.
-
-    """
-    if os.path.splitext(fastq)[1] == '.gz':
-        return gzip.open(fastq,mode)
-    else:
-        return io.open(fastq,mode)
-
-def nreads(fastq=None,fp=None):
-    """Return number of reads in a FASTQ file
-
-    Performs a simple-minded read count, by counting the number of lines
-    in the file and dividing by 4.
-
-    The FASTQ file can be specified either as a file name (using the 'fastq'
-    argument) or as a file-like object opened for line reading (using the
-    'fp' argument).
-
-    This function can handle gzipped FASTQ files supplied via the 'fastq'
-    argument.
-
-    Line counting uses a variant of the "buf count" method outlined here:
-    http://stackoverflow.com/a/850962/579925
-
-    Arguments:
-      fastq: fastq(.gz) file
-      fp: open file descriptor for fastq file
-
-    Returns:
-      Number of reads
-
-    """
-    nlines = 0
-    if fp is None:
-        fp = get_fastq_file_handle(fastq)
-    buf_size = 1024 * 1024
-    read_fp = fp.read # optimise the loop
-    buf = read_fp(buf_size)
-    while buf:
-        nlines += buf.count('\n')
-        buf = read_fp(buf_size)
-    if fastq is not None:
-        fp.close()
-    if (nlines%4) != 0:
-        raise Exception("Bad read count (not fastq file, or corrupted?)")
-    return nlines/4
-
-def fastqs_are_pair(fastq1=None,fastq2=None,verbose=True,fp1=None,fp2=None):
-    """Check that two FASTQs form an R1/R2 pair
-
-    Arguments:
-      fastq1: first FASTQ
-      fastq2: second FASTQ
-
-    Returns:
-      True if each read in fastq1 forms an R1/R2 pair with the equivalent
-      read (i.e. in the same position) in fastq2, otherwise False if
-      any do not form an R1/R2 (or if there are more reads in one than
-      than the other).
-
-    """
-    # Use izip_longest, which will return None if either of
-    # the fastqs is exhausted before the other
-    i = 0
-    for r1,r2 in itertools.zip_longest(
-            FastqIterator(fastq_file=fastq1,fp=fp1),
-            FastqIterator(fastq_file=fastq2,fp=fp2)):
-        i += 1
-        if verbose:
-            if i%100000 == 0:
-                print("Examining pair #%d" % i)
-        if not r1.seqid.is_pair_of(r2.seqid):
-            if verbose:
-                print("Unpaired headers for read position #%d:" % i)
-                print("%s\n%s" % (r1.seqid,r2.seqid))
-            return False
-    return True

--- a/bcftbx/cli/verify_paired.py
+++ b/bcftbx/cli/verify_paired.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     verify_paired.py: check R1 and R2 fastq files are consistent
-#     Copyright (C) University of Manchester 2013-2021 Peter Briggs
+#     Copyright (C) University of Manchester 2013-2026 Peter Briggs
 #
 
 """
@@ -15,13 +15,11 @@ the files form an R1/2 pair.
 # Imports
 #######################################################################
 
-import os
 import sys
-import itertools
 import argparse
 import logging
 logging.basicConfig(format="%(levelname)s %(message)s")
-from ..FASTQFile import fastqs_are_pair
+from ..io.fastq import fastqs_are_pair
 from .. import get_version
 
 #######################################################################

--- a/bcftbx/io/fastq.py
+++ b/bcftbx/io/fastq.py
@@ -15,7 +15,7 @@ Classes for reading FASTQ files and manipulating the data within them:
 Additionally, there are a few utility functions:
 
 * get_fastq_file_handle: return a file handled opened for reading a FASTQ file
-* nreads: return the number of reads in a FASTQ file
+* count_reads: return the number of reads in a FASTQ file
 * fastqs_are_pair: check whether two FASTQs form an R1/R2 pair
 
 Information on the FASTQ file format: http://en.wikipedia.org/wiki/FASTQ_format
@@ -435,8 +435,9 @@ def get_fastq_file_handle(fastq, mode="rt"):
         return open(fastq,mode)
 
 
-def nreads(fastq=None,fp=None):
-    """Return number of reads in a FASTQ file
+def count_reads(fastq=None, fp=None):
+    """
+    Count number of reads in a FASTQ file
 
     Performs a simple-minded read count, by counting the number of lines
     in the file and dividing by 4.
@@ -452,15 +453,15 @@ def nreads(fastq=None,fp=None):
     http://stackoverflow.com/a/850962/579925
 
     Arguments:
-      fastq: fastq(.gz) file
-      fp: open file descriptor for fastq file
+      fastq (str): fastq(.gz) file
+      fp (any): open file descriptor for fastq file
 
     Returns:
-      Number of reads
+      Integer: number of reads in the FASTQ file.
     """
     nlines = 0
     if fp is None:
-        fp = get_fastq_file_handle(fastq)
+        fp = get_fastq_file_handle(os.path.abspath(fastq))
     buf_size = 1024 * 1024
     read_fp = fp.read # optimise the loop
     buf = read_fp(buf_size)

--- a/bcftbx/io/fastq.py
+++ b/bcftbx/io/fastq.py
@@ -475,13 +475,18 @@ def count_reads(fastq=None, fp=None):
     return nlines/4
 
 
-def fastqs_are_pair(fastq1=None,fastq2=None,verbose=True,fp1=None,fp2=None):
+def fastqs_are_pair(fastq1=None, fastq2=None, fp1=None, fp2=None, verbose=True):
     """
     Check that two FASTQs form an R1/R2 pair
 
     Arguments:
-      fastq1: first FASTQ
-      fastq2: second FASTQ
+        fastq1 (str): first FASTQ
+        fastq2 (str): second FASTQ
+        fp1 (any): file descriptor for first FASTQ (alternative to supplying a
+            file path)
+        fp2 (any): file descriptor for second FASTQ (alternative to supplying a
+            file path)
+        verbose (bool): produce verbose output
 
     Returns:
       Boolean: True if each read in fastq1 forms an R1/R2 pair with the equivalent

--- a/bcftbx/io/fastq.py
+++ b/bcftbx/io/fastq.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python3
+#
+#     fastq.py: classes and utilities handling FASTQ files
+#     Copyright (C) University of Manchester 2026 Peter Briggs
+#
+
+
+"""
+Classes for reading FASTQ files and manipulating the data within them:
+
+* FastqIterator: enables looping through all read records in FASTQ file
+* FastqRead: provides access to a single FASTQ read record
+* SequenceIdentifier: provides access to sequence identifier info in a read
+* FastqAttributes: provides access to 'gross' attributes of FASTQ file
+
+Additionally, there are a few utility functions:
+
+* get_fastq_file_handle: return a file handled opened for reading a FASTQ file
+* nreads: return the number of reads in a FASTQ file
+* fastqs_are_pair: check whether two FASTQs form an R1/R2 pair
+
+Information on the FASTQ file format: http://en.wikipedia.org/wiki/FASTQ_format
+"""
+
+
+import os
+import re
+import gzip
+from collections.abc import Iterator
+from itertools import zip_longest
+
+
+# Size of chunks to get when reading data from files
+CHUNKSIZE = 102400
+
+# Precompiled regular expressions
+
+# Match Illumina 1.8+ format, e.g.:
+# @EAS139:136:FC706VJ:2:2104:15343:197393 1:Y:18:ATCACG
+RE_ILLUMINA18 = re.compile(r"^@([^:]+):([0-9]+):([^:]+):([0-9]+):([0-9]+):([0-9]+):([0-9]+) (1|2|3):(Y|N):([0-9]+):(.*)$")
+#
+# Match  earlier Illumina format (1.3/1.5), e.g.:
+# @HWUSI-EAS100R:6:73:941:1973#0/1
+RE_ILLUMINA = re.compile(r"^@([^:]+):([0-9]+):([0-9]+):([0-9]+):([0-9]+)#([0-9]+)/(1|2)$")
+
+
+class FastqIterator(Iterator):
+    """
+    Iterator for looping over all records in a FASTQ file.
+
+    Each record is returned as a ``FastqRead`` object.
+
+    Example usage:
+
+    >>> for read in FastqIterator(fastq_file):
+    >>>    print(read)
+
+    or with a file handle:
+
+    >>> with open(fastq_file, "rt") as fp:
+    ...     for read in FastqIterator(fp=fp):
+    ...         print(read)
+
+    The input FASTQ can be either a text file or a compressed (gzipped)
+    file, and specified either as a file name or as a file-like object
+    opened for line reading.
+
+    Arguments:
+        fastq_file (str): name of the FASTQ file to iterate through
+        fp (any): file-like object opened for reading
+        bufsize (int): optional integer specifying number of bytes to
+            read as a single 'chunk' from disk
+    """
+    def __init__(self, fastq_file=None, fp=None, bufsize=CHUNKSIZE):
+        self._fastq_file = fastq_file
+        self._bufsize = bufsize
+        if fp is None:
+            self._fp = get_fastq_file_handle(self._fastq_file, "rt")
+        else:
+            self._fp = fp
+        self._buf = ''
+        self._lines = []
+        self._ip = 0
+
+    def __next__(self):
+        """
+        Return next record from FASTQ file as a ``FastqRead`` object
+        """
+        # Convenience variables
+        lines = self._lines
+        buf = self._buf
+        ip = self._ip
+        bufsize = self._bufsize
+        # Do we already have a read to return?
+        while len(lines) < 4:
+            # Fetch more data
+            data = self._fp.read(bufsize)
+            if not data:
+                # Reached EOF
+                if self._fastq_file is not None:
+                    self._fp.close()
+                raise StopIteration
+            # Add to buffer and split into lines
+            buf = buf + data
+            if buf[-1] != '\n':
+                i = buf.rfind('\n')
+                if i == -1:
+                    continue
+                else:
+                    lines.extend(buf[:i].split('\n'))
+                    buf = buf[i+1:]
+            else:
+                lines.extend(buf[:-1].split('\n'))
+                buf = ''
+        # Return a read
+        read = lines[ip:ip + 4]
+        ip = ip + 4
+        if (len(lines) - ip) < 4:
+            # Not enough lines for another read so
+            # reset the buffer
+            lines = lines[ip:]
+            ip = 0
+        # Update internals
+        self._lines = lines
+        self._buf = buf
+        self._ip = ip
+        return FastqRead(*read)
+
+
+class FastqRead:
+    """
+    Class representing a FASTQ record
+
+    Provides the following properties for accessing the read data:
+
+    - ``header``: the "sequence identifier" information (first line of the
+      read record) as a ``SequenceIdentifier`` object
+    - ``sequence``: the raw sequence (second line of the record)
+    - ``optid``: the optional sequence identifier line (third line of the
+      record)
+    - ``quality``: the quality values (fourth line of the record)
+
+    Additional properties:
+
+    - ``raw_header``: the original sequence identifier string supplied
+      when the object was created
+    - ``max_quality``: maximum quality value (in character representation)
+    - ``min_quality``: minimum quality value (in character representation)
+    - ``is_colorspace``: returns True if the read looks like a colorspace
+      read, False otherwise
+
+    The sequence length is returned via the ``len`` built-in function.
+
+    .. note::
+
+       Quality scores can only be obtained from character
+       representations once the encoding scheme is known.
+
+    Arguments:
+        header (str): Fastq read "header" (first line of the read)
+        sequence (str): read sequence (second line of the record)
+        optid (str): third line of the record (typically ``+``)
+        quality (str): encoded quality scores (fourth line of the record)
+    """
+    def __init__(self, header=None, sequence=None, optid=None, quality=None):
+        self._raw_header = str(header).rstrip()
+        self._sequence = str(sequence).rstrip()
+        self._optid = str(optid).rstrip()
+        self._quality = str(quality).rstrip()
+
+    @property
+    def header(self):
+        """
+        Return the Fastq header as a ``SequenceIdentifier`` object
+        """
+        try:
+            return self._header
+        except AttributeError:
+            self._header = SequenceIdentifier(self._raw_header)
+            return self._header
+
+    @property
+    def sequence(self):
+        """
+        Return the sequence associated with the read
+        """
+        return self._sequence
+
+    @property
+    def quality(self):
+        """
+        Return the encoded quality scores associated with the read
+        """
+        return self._quality
+
+    @property
+    def optid(self):
+        """
+        Return the encoded quality scores associated with the read
+        """
+        return self._optid
+
+    @property
+    def raw_header(self):
+        """
+        Return the 'raw' Fastq header
+        """
+        return self._raw_header
+
+    @property
+    def max_quality(self):
+        """
+        Return the maximum quality score associated with the read
+        """
+        try:
+            # Cached value
+            return self._maxqual
+        except AttributeError:
+            # Compute, store and return
+            if self.quality:
+                self._maxqual = max(self.quality)
+            else:
+                self._maxqual = ''
+        return self._maxqual
+
+    @property
+    def min_quality(self):
+        """
+        Return the minimum quality score associated with the read
+        """
+        try:
+            # Cached value
+            return self._minqual
+        except AttributeError:
+            # Compute, store and return
+            if self.quality:
+                self._minqual = min(self.quality)
+            else:
+                self._minqual = ''
+        return self._minqual
+
+    @property
+    def is_colorspace(self):
+        try:
+            return self._is_colorspace
+        except AttributeError:
+            pass
+        if self.header.format is None:
+            # Check if it looks like colorspace
+            # Sequence starts with 'T' and only contains characters
+            # 0-3 or '.'
+            sequence = self.sequence
+            if sequence.startswith('T'):
+                for c in sequence[1:]:
+                    if c not in '.0123':
+                        self._is_colorspace = False
+                        return self._is_colorspace
+                # Passed colorspace tests
+                self._is_colorspace = True
+                return self._is_colorspace
+        # Not colorspace
+        self._is_colorspace = False
+        return self._is_colorspace
+
+    def __repr__(self):
+        return '\n'.join((str(self.header),
+                          self.sequence,
+                          self.optid,
+                          self.quality))
+
+    def __eq__(self,other):
+        return (str(self) == str(other))
+
+    def __len__(self):
+        try:
+            return self._sequence_length
+        except AttributeError:
+            if self.is_colorspace:
+                self._sequence_length = len(self._sequence) - 1
+            else:
+                self._sequence_length = len(self._sequence)
+            return self._sequence_length
+
+
+class SequenceIdentifier:
+    """
+    Class for handling sequence identifier information from a FASTQ read header
+
+    Provides access to the data items in the sequence identifier line of a FASTQ
+    record.
+
+    Arguments:
+        fastq_header (str): the sequence identifier line (i.e. first/header
+            line) from the FASTQ read record
+    """
+    def __init__(self, fastq_header):
+        self._fastq_header = str(fastq_header).rstrip()
+        self.instrument_name = None
+        self.run_id = None
+        self.flowcell_id = None
+        self.flowcell_lane = None
+        self.tile_no = None
+        self.x_coord = None
+        self.y_coord = None
+        self.multiplex_index_no = None
+        self.pair_id =  None
+        self.bad_read = None
+        self.control_bit_flag = None
+        self.index_sequence = None
+        self._format = None
+        # Identify sequence id line elements
+        m = RE_ILLUMINA18.match(self._fastq_header)
+        if m:
+            # example of Illumina 1.8+ format:
+            # @EAS139:136:FC706VJ:2:2104:15343:197393 1:Y:18:ATCACG
+            self._format = 'illumina18'
+            self.instrument_name = m.group(1)
+            self.run_id = m.group(2)
+            self.flowcell_id = m.group(3)
+            self.flowcell_lane = m.group(4)
+            self.tile_no = m.group(5)
+            self.x_coord = m.group(6)
+            self.y_coord = m.group(7)
+            self.pair_id = m.group(8)
+            self.bad_read = m.group(9)
+            self.control_bit_flag = m.group(10)
+            self.index_sequence = m.group(11)
+        else:
+            # Example of earlier Illumina format (1.3/1.5):
+            # @HWUSI-EAS100R:6:73:941:1973#0/1
+            m = RE_ILLUMINA.match(self._fastq_header)
+            if m:
+                self._format = 'illumina'
+                self.instrument_name = m.group(1)
+                self.flowcell_lane = m.group(2)
+                self.tile_no = m.group(3)
+                self.x_coord = m.group(4)
+                self.y_coord = m.group(5)
+                self.multiplex_index_no = m.group(6)
+                self.pair_id = m.group(7)
+
+    @property
+    def format(self):
+        """
+        Identify the format of the sequence identifier
+
+        Returns:
+          String: 'illumina18', 'illumina' or None
+        """
+        try:
+            return self._format
+        except AttributeError:
+            pass
+
+    def is_pair_of(self, seqid):
+        """
+        Check if this forms a pair with another SequenceIdentifier
+
+        Two identifiers are a pair if they are identical except for the
+        read number (which should be 1 for one of them, and 2 for the
+        other).
+
+        Arguments:
+            seqid (SequenceIdentifier): the identifier to compare against
+
+        Returns:
+            Boolean: True if this forms a pair with another SequenceIdentifier,
+                False if not.
+        """
+        # Check we have r1/r2
+        read_indices = [int(self.pair_id), int(seqid.pair_id)]
+        read_indices.sort()
+        if read_indices != [1,2]:
+            return False
+        # Check all other attributes match
+        try:
+            return (self.instrument_name  == seqid.instrument_name and
+                    self.run_id           == seqid.run_id and
+                    self.flowcell_id      == seqid.flowcell_id and
+                    self.flowcell_lane    == seqid.flowcell_lane and
+                    self.tile_no          == seqid.tile_no and
+                    self.x_coord          == seqid.x_coord and
+                    self.y_coord          == seqid.y_coord and
+                    self.multiplex_index_no == seqid.multiplex_index_no and
+                    self.bad_read         == seqid.bad_read and
+                    self.control_bit_flag == seqid.control_bit_flag and
+                    self.index_sequence   == seqid.index_sequence)
+        except Exception:
+            return False
+
+    def __repr__(self):
+        if self.format == 'illumina18':
+            return "@%s:%s:%s:%s:%s:%s:%s %s:%s:%s:%s" % (self.instrument_name,
+                                                          self.run_id,
+                                                          self.flowcell_id,
+                                                          self.flowcell_lane,
+                                                          self.tile_no,
+                                                          self.x_coord,
+                                                          self.y_coord,
+                                                          self.pair_id,
+                                                          self.bad_read,
+                                                          self.control_bit_flag,
+                                                          self.index_sequence)
+        elif self.format == 'illumina':
+            return "@%s:%s:%s:%s:%s#%s/%s" % (self.instrument_name,
+                                              self.flowcell_lane,
+                                              self.tile_no,
+                                              self.x_coord,
+                                              self.y_coord,
+                                              self.multiplex_index_no,
+                                              self.pair_id)
+        else:
+            # Return what was put in
+            return self._fastq_header
+
+
+class FastqAttributes:
+    """
+    Class to access "gross" attributes of a FASTQ file
+
+    Given a FASTQ file (can be uncompressed or gzipped), enables
+    various attributes to be queried via the following properties:
+
+    - ``nreads``: number of reads in the FASTQ file
+    - ``fsize``:  size of the file (in bytes)
+
+    Arguments:
+        fastq_file (str): name of the FASTQ file
+        fp (any): file pointer to read from
+    """
+    def __init__(self, fastq=None, fp=None):
+        self._fastq = fastq
+        if self._fastq:
+            self._fastq = os.path.abspath(self._fastq)
+        self._fp = fp
+        if self._fp is None:
+            self._fp = get_fastq_file_handle(self._fastq)
+        self._nreads = None
+        self._fsize = None
+
+    @property
+    def nreads(self):
+        """
+        Return number of reads in the FASTQ file
+        """
+        if self._nreads is None:
+            self._nreads = nreads(fastq=self._fastq, fp=self._fp)
+        return self._nreads
+
+    @property
+    def fsize(self):
+        """
+        Return size of the FASTQ file (bytes)
+        """
+        if self._fsize is None:
+            try:
+                self._fsize = os.path.getsize(self._fastq)
+            except Exception as ex:
+                if self._fastq is None:
+                    raise Exception(f"Cannot fetch FASTQ size without a file name")
+                else:
+                    raise ex
+        return self._fsize
+
+
+def get_fastq_file_handle(fastq, mode="rt"):
+    """
+    Return a file handle opened for reading for a FASTQ file
+
+    Deals with both compressed (gzipped) and uncompressed FASTQ
+    files.
+
+    Arguments:
+        fastq (str): name (including path, if required) of FASTQ
+            file. The file can be gzipped (must have '.gz'
+            extension)
+        mode (str): optional mode for file opening (defaults to 'rt')
+
+    Returns:
+      Object: file handle that can be used for read operations.
+    """
+    if os.path.splitext(fastq)[1] == '.gz':
+        return gzip.open(fastq,mode)
+    else:
+        return open(fastq,mode)
+
+
+def nreads(fastq=None,fp=None):
+    """Return number of reads in a FASTQ file
+
+    Performs a simple-minded read count, by counting the number of lines
+    in the file and dividing by 4.
+
+    The FASTQ file can be specified either as a file name (using the 'fastq'
+    argument) or as a file-like object opened for line reading (using the
+    'fp' argument).
+
+    This function can handle gzipped FASTQ files supplied via the 'fastq'
+    argument.
+
+    Line counting uses a variant of the "buf count" method outlined here:
+    http://stackoverflow.com/a/850962/579925
+
+    Arguments:
+      fastq: fastq(.gz) file
+      fp: open file descriptor for fastq file
+
+    Returns:
+      Number of reads
+    """
+    nlines = 0
+    if fp is None:
+        fp = get_fastq_file_handle(fastq)
+    buf_size = 1024 * 1024
+    read_fp = fp.read # optimise the loop
+    buf = read_fp(buf_size)
+    while buf:
+        nlines += buf.count('\n')
+        buf = read_fp(buf_size)
+    if fastq is not None:
+        fp.close()
+    if (nlines%4) != 0:
+        raise Exception("Bad read count (not fastq file, or corrupted?)")
+    return nlines/4
+
+
+def fastqs_are_pair(fastq1=None,fastq2=None,verbose=True,fp1=None,fp2=None):
+    """
+    Check that two FASTQs form an R1/R2 pair
+
+    Arguments:
+      fastq1: first FASTQ
+      fastq2: second FASTQ
+
+    Returns:
+      Boolean: True if each read in fastq1 forms an R1/R2 pair with the equivalent
+        read (i.e. in the same position) in fastq2, otherwise False if
+        any do not form an R1/R2 (or if there are more reads in one than
+        the other).
+    """
+    # Use zip_longest, which will return None if either of
+    # the fastqs is exhausted before the other
+    i = 0
+    for r1,r2 in zip_longest(
+            FastqIterator(fastq_file=fastq1,fp=fp1),
+            FastqIterator(fastq_file=fastq2,fp=fp2)):
+        i += 1
+        if verbose:
+            if i%100000 == 0:
+                print("Examining pair #%d" % i)
+        if not r1.header.is_pair_of(r2.header):
+            if verbose:
+                print("Unpaired headers for read position #%d:" % i)
+                print("%s\n%s" % (r1.header, r2.header))
+            return False
+    return True

--- a/bcftbx/io/fastq.py
+++ b/bcftbx/io/fastq.py
@@ -70,8 +70,10 @@ class FastqIterator(Iterator):
         bufsize (int): optional integer specifying number of bytes to
             read as a single 'chunk' from disk
     """
-    def __init__(self, fastq_file=None, fp=None, bufsize=CHUNKSIZE):
+    def __init__(self, fastq_file=None, fp=None, bufsize=None):
         self._fastq_file = fastq_file
+        if bufsize is None:
+            bufsize = CHUNKSIZE
         self._bufsize = bufsize
         if fp is None:
             self._fp = get_fastq_file_handle(self._fastq_file, "rt")
@@ -123,6 +125,12 @@ class FastqIterator(Iterator):
         self._lines = lines
         self._buf = buf
         self._ip = ip
+        return self._fastq_read(read)
+
+    def _fastq_read(self, read):
+        # Internal, return an instance of the appropriate class
+        # Subclasses should override this if they're using a
+        # different class
         return FastqRead(*read)
 
 
@@ -175,7 +183,7 @@ class FastqRead:
         try:
             return self._header
         except AttributeError:
-            self._header = SequenceIdentifier(self._raw_header)
+            self._header = self._sequencer_identifier(self._raw_header)
             return self._header
 
     @property
@@ -260,6 +268,12 @@ class FastqRead:
         # Not colorspace
         self._is_colorspace = False
         return self._is_colorspace
+
+    def _sequencer_identifier(self, fastq_header):
+        # Internal, use this to an instance of the appropriate class
+        # Subclasses should override this if they're using a
+        # different class
+        return SequenceIdentifier(fastq_header)
 
     def __repr__(self):
         return '\n'.join((str(self.header),

--- a/bcftbx/io/fastq.py
+++ b/bcftbx/io/fastq.py
@@ -11,7 +11,6 @@ Classes for reading FASTQ files and manipulating the data within them:
 * FastqIterator: enables looping through all read records in FASTQ file
 * FastqRead: provides access to a single FASTQ read record
 * SequenceIdentifier: provides access to sequence identifier info in a read
-* FastqAttributes: provides access to 'gross' attributes of FASTQ file
 
 Additionally, there are a few utility functions:
 
@@ -412,55 +411,6 @@ class SequenceIdentifier:
         else:
             # Return what was put in
             return self._fastq_header
-
-
-class FastqAttributes:
-    """
-    Class to access "gross" attributes of a FASTQ file
-
-    Given a FASTQ file (can be uncompressed or gzipped), enables
-    various attributes to be queried via the following properties:
-
-    - ``nreads``: number of reads in the FASTQ file
-    - ``fsize``:  size of the file (in bytes)
-
-    Arguments:
-        fastq_file (str): name of the FASTQ file
-        fp (any): file pointer to read from
-    """
-    def __init__(self, fastq=None, fp=None):
-        self._fastq = fastq
-        if self._fastq:
-            self._fastq = os.path.abspath(self._fastq)
-        self._fp = fp
-        if self._fp is None:
-            self._fp = get_fastq_file_handle(self._fastq)
-        self._nreads = None
-        self._fsize = None
-
-    @property
-    def nreads(self):
-        """
-        Return number of reads in the FASTQ file
-        """
-        if self._nreads is None:
-            self._nreads = nreads(fastq=self._fastq, fp=self._fp)
-        return self._nreads
-
-    @property
-    def fsize(self):
-        """
-        Return size of the FASTQ file (bytes)
-        """
-        if self._fsize is None:
-            try:
-                self._fsize = os.path.getsize(self._fastq)
-            except Exception as ex:
-                if self._fastq is None:
-                    raise Exception(f"Cannot fetch FASTQ size without a file name")
-                else:
-                    raise ex
-        return self._fsize
 
 
 def get_fastq_file_handle(fastq, mode="rt"):

--- a/bcftbx/test/io/test_fastq.py
+++ b/bcftbx/test/io/test_fastq.py
@@ -207,7 +207,7 @@ class TestFastqRead(unittest.TestCase):
         quality = "=@@D;DDFFHDHHIJIIIIIIGIGIGDIHGGEIGICFGIGHIIGII@?FGIGIEI@EHEFFEEBAACD;@ACCDDBDBDDACCC3>CD>:ADCCDDD?C@\n"
         read = FastqRead(header, sequence, optid, quality)
         self.assertTrue(isinstance(read.header, SequenceIdentifier))
-        self.assertEqual(str(read.header), sequence.rstrip('\n'))
+        self.assertEqual(str(read.header), header.rstrip('\n'))
         self.assertEqual(read.raw_header, header.rstrip('\n'))
         self.assertEqual(read.sequence, sequence.rstrip('\n'))
         self.assertEqual(read.optid, optid.rstrip('\n'))

--- a/bcftbx/test/io/test_fastq.py
+++ b/bcftbx/test/io/test_fastq.py
@@ -1,0 +1,484 @@
+#######################################################################
+# Tests for io.fastq.py module
+#######################################################################
+
+
+import unittest
+import os
+import gzip
+import shutil
+import tempfile
+from io import StringIO
+from bcftbx.io.fastq import FastqIterator
+from bcftbx.io.fastq import FastqRead
+from bcftbx.io.fastq import SequenceIdentifier
+from bcftbx.io.fastq import FastqAttributes
+from bcftbx.io.fastq import nreads
+from bcftbx.io.fastq import fastqs_are_pair
+
+
+# Test data for an R1 Fastq
+FASTQ_DATA_R1 = """@73D9FA:3:FC:1:1:7507:1000 1:N:0:
+NACAACCTGATTAGCGGCGTTGACAGATGTATCCAT
++
+#))))55445@@@@@C@@@@@@@@@:::::<<:::<
+@73D9FA:3:FC:1:1:15740:1000 1:N:0:
+NTCTTGCTGGTGGCGCCATGTCTAAATTGTTTGGAG
++
+#+.))/0200<<<<<:::::CC@@C@CC@@@22@@@
+@73D9FA:3:FC:1:1:8103:1000 1:N:0:
+NGACCGATTAGAGGCGTTTTATGATAATCCCAATGC
++
+#(,((,)*))/.0--2255282299@@@@@@@@@@@
+@73D9FA:3:FC:1:1:7488:1000 1:N:0:
+NTGATTGTCCAGTTGCATTTTAGTAAGCTCTTTTTG
++
+#,,,,33223CC@@@@@@@C@@@@@@@@C@CC@222
+@73D9FA:3:FC:1:1:6680:1000 1:N:0:
+NATAAATCACCTCACTTAAGTGGCTGGAGACAAATA
++
+#--,,55777@@@@@@@CC@@C@@@@@@@@:::::<
+"""
+
+# Test data for an R2 Fastq matching the previous data
+FASTQ_DATA_R2 = u"""@73D9FA:3:FC:1:1:7507:1000 2:N:0:
+NACAACCTGATTAGCGGCGTTGACAGATGTATCCAT
++
+#))))55445@@@@@C@@@@@@@@@:::::<<:::<
+@73D9FA:3:FC:1:1:15740:1000 2:N:0:
+NTCTTGCTGGTGGCGCCATGTCTAAATTGTTTGGAG
++
+#+.))/0200<<<<<:::::CC@@C@CC@@@22@@@
+@73D9FA:3:FC:1:1:8103:1000 2:N:0:
+NGACCGATTAGAGGCGTTTTATGATAATCCCAATGC
++
+#(,((,)*))/.0--2255282299@@@@@@@@@@@
+@73D9FA:3:FC:1:1:7488:1000 2:N:0:
+NTGATTGTCCAGTTGCATTTTAGTAAGCTCTTTTTG
++
+#,,,,33223CC@@@@@@@C@@@@@@@@C@CC@222
+@73D9FA:3:FC:1:1:6680:1000 2:N:0:
+NATAAATCACCTCACTTAAGTGGCTGGAGACAAATA
++
+#--,,55777@@@@@@@CC@@C@@@@@@@@:::::<
+"""
+
+# Test data for a Fastq with an "empty" sequence
+FASTQ_WITH_EMPTY_SEQUENCE = """@73D9FA:3:FC:1:1:7507:1000 1:N:0:
+NACAACCTGATTAGCGGCGTTGACAGATGTATCCAT
++
+#))))55445@@@@@C@@@@@@@@@:::::<<:::<
+@73D9FA:3:FC:1:1:15740:1000 1:N:0:
+NTCTTGCTGGTGGCGCCATGTCTAAATTGTTTGGAG
++
+#+.))/0200<<<<<:::::CC@@C@CC@@@22@@@
+@73D9FA:3:FC:1:1:8103:1000 1:N:0:
+NGACCGATTAGAGGCGTTTTATGATAATCCCAATGC
++
+#(,((,)*))/.0--2255282299@@@@@@@@@@@
+@73D9FA:3:FC:1:1:7488:1000 1:N:0:
+
++
+
+@73D9FA:3:FC:1:1:6680:1000 1:N:0:
+NATAAATCACCTCACTTAAGTGGCTGGAGACAAATA
++
+#--,,55777@@@@@@@CC@@C@@@@@@@@:::::<
+"""
+
+
+class TestFastqIterator(unittest.TestCase):
+    """
+    Tests of the FastqIterator class
+    """
+    def setUp(self):
+        # Temporary working dir
+        self.wd = tempfile.mkdtemp(suffix='.TestFastqIterator')
+
+    def tearDown(self):
+        # Remove temporary working dir
+        if os.path.isdir(self.wd):
+            shutil.rmtree(self.wd)
+
+    def test_fastq_iterator(self):
+        """
+        FastqIterator: iterate over FASTQ file
+        """
+        fp = StringIO(FASTQ_DATA_R1)
+        fastq = FastqIterator(fp=fp)
+        nreads = 0
+        fastq_source = StringIO(FASTQ_DATA_R1)
+        for read in fastq:
+            nreads += 1
+            self.assertTrue(isinstance(read.header, SequenceIdentifier))
+            self.assertEqual(str(read.header),fastq_source.readline().rstrip('\n'))
+            self.assertEqual(read.sequence,fastq_source.readline().rstrip('\n'))
+            self.assertEqual(read.optid,fastq_source.readline().rstrip('\n'))
+            self.assertEqual(read.quality,fastq_source.readline().rstrip('\n'))
+        self.assertEqual(nreads,5)
+
+    def test_fastq_iterator_empty_sequence(self):
+        """
+        FastqIterator: handle 'empty' sequence
+        """
+        fp = StringIO(FASTQ_WITH_EMPTY_SEQUENCE)
+        fastq = FastqIterator(fp=fp)
+        nreads = 0
+        fastq_source = StringIO(FASTQ_WITH_EMPTY_SEQUENCE)
+        for read in fastq:
+            nreads += 1
+            self.assertTrue(isinstance(read.header, SequenceIdentifier))
+            self.assertEqual(str(read.header),fastq_source.readline().rstrip('\n'))
+            self.assertEqual(read.sequence,fastq_source.readline().rstrip('\n'))
+            self.assertEqual(read.optid,fastq_source.readline().rstrip('\n'))
+            self.assertEqual(read.quality,fastq_source.readline().rstrip('\n'))
+        self.assertEqual(nreads,5)
+
+    def test_fastq_iterator_empty_sequence_at_buffer_start(self):
+        """
+        FastqIterator: handle 'empty' sequence with small buffer
+        """
+        # Checks we can handle an edge case where the newline
+        # terminating the 'empty' sequence falls at the start
+        # of the read buffer.
+        fp = StringIO(FASTQ_WITH_EMPTY_SEQUENCE)
+        fastq = FastqIterator(fp=fp,bufsize=2)
+        nreads = 0
+        fastq_source = StringIO(FASTQ_WITH_EMPTY_SEQUENCE)
+        for read in fastq:
+            nreads += 1
+            self.assertTrue(isinstance(read.header, SequenceIdentifier))
+            self.assertEqual(str(read.header),fastq_source.readline().rstrip('\n'))
+            self.assertEqual(read.sequence,fastq_source.readline().rstrip('\n'))
+            self.assertEqual(read.optid,fastq_source.readline().rstrip('\n'))
+            self.assertEqual(read.quality,fastq_source.readline().rstrip('\n'))
+        self.assertEqual(nreads,5)
+
+    def test_fastq_iterator_file_from_disk(self):
+        """
+        FastqIterator: iterate over FASTQ file from disk
+        """
+        self.fastq_in = os.path.join(self.wd,'test.fq')
+        with open(self.fastq_in, "wt") as fp:
+            fp.write(FASTQ_DATA_R1)
+        fastq = FastqIterator(self.fastq_in)
+        nreads = 0
+        fastq_source = StringIO(FASTQ_DATA_R1)
+        for read in fastq:
+            nreads += 1
+            self.assertTrue(isinstance(read.header, SequenceIdentifier))
+            self.assertEqual(str(read.header), fastq_source.readline().rstrip('\n'))
+            self.assertEqual(read.sequence,fastq_source.readline().rstrip('\n'))
+            self.assertEqual(read.optid,fastq_source.readline().rstrip('\n'))
+            self.assertEqual(read.quality,fastq_source.readline().rstrip('\n'))
+        self.assertEqual(nreads,5)
+
+    def test_fastq_iterator_gzipped_file_from_disk(self):
+        """
+        FastqIterator: iterate over gzipped FASTQ file from disk
+        """
+        self.fastq_in = os.path.join(self.wd,'test.fq.gz')
+        with gzip.open(self.fastq_in,'wt') as fp:
+            fp.write(FASTQ_DATA_R1)
+        fastq = FastqIterator(self.fastq_in)
+        nreads = 0
+        fastq_source = StringIO(FASTQ_DATA_R1)
+        for read in fastq:
+            nreads += 1
+            self.assertTrue(isinstance(read.header, SequenceIdentifier))
+            self.assertEqual(str(read.header), fastq_source.readline().rstrip('\n'))
+            self.assertEqual(read.sequence,fastq_source.readline().rstrip('\n'))
+            self.assertEqual(read.optid,fastq_source.readline().rstrip('\n'))
+            self.assertEqual(read.quality,fastq_source.readline().rstrip('\n'))
+        self.assertEqual(nreads,5)
+
+
+class TestFastqRead(unittest.TestCase):
+    """
+    Tests of the FastqRead class
+    """
+    def test_fastqread(self):
+        """
+        FastqRead: check stores input correctly
+        """
+        header = "@HWI-ST1250:47:c0tr3acxx:4:1101:1283:2323 1:N:0:ACAGTGATTCTTTCCC\n"
+        sequence = "GGTGTCTTCAAAAAGGCCAACCAGATAGGCCTCACTTGCCTCCTGCAAAGCACCGATAGCTGCGCTCTGGAAGCGCAGATCTGTTTTAAAGTCCTGAGCAA\n"
+        optid = "+\n"
+        quality = "=@@D;DDFFHDHHIJIIIIIIGIGIGDIHGGEIGICFGIGHIIGII@?FGIGIEI@EHEFFEEBAACD;@ACCDDBDBDDACCC3>CD>:ADCCDDD?C@\n"
+        read = FastqRead(header, sequence, optid, quality)
+        self.assertTrue(isinstance(read.header, SequenceIdentifier))
+        self.assertEqual(str(read.header), sequence.rstrip('\n'))
+        self.assertEqual(read.raw_header, header.rstrip('\n'))
+        self.assertEqual(read.sequence, sequence.rstrip('\n'))
+        self.assertEqual(read.optid, optid.rstrip('\n'))
+        self.assertEqual(read.quality, quality.rstrip('\n'))
+        self.assertEqual(len(read), len(sequence.rstrip('\n')))
+        self.assertEqual(read.max_quality,'J')
+        self.assertEqual(read.min_quality,'3')
+        self.assertFalse(read.is_colorspace)
+
+    def test_fastqread_empty_sequence(self):
+        """
+        FastqRead: handles 'empty' sequence
+        """
+        header = "@HWI-ST1250:47:c0tr3acxx:4:1101:1283:2323 1:N:0:ACAGTGATTCTTTCCC"
+        sequence = ""
+        optid = "+"
+        quality = ""
+        read = FastqRead(header, sequence, optid, quality)
+        self.assertTrue(isinstance(read.header, SequenceIdentifier))
+        self.assertEqual(str(read.header), header.rstrip('\n'))
+        self.assertEqual(read.raw_header, header.rstrip('\n'))
+        self.assertEqual(read.sequence, sequence.rstrip('\n'))
+        self.assertEqual(read.optid, optid.rstrip('\n'))
+        self.assertEqual(read.quality, quality.rstrip('\n'))
+        self.assertEqual(len(read), len(sequence.rstrip('\n')))
+        self.assertEqual(read.max_quality,'')
+        self.assertEqual(read.min_quality,'')
+        self.assertFalse(read.is_colorspace)
+
+    def test_is_colorspace(self):
+        """
+        FastqRead: detect colorspace read
+        """
+        read = FastqRead("@1_14_622",
+                         "T221.0033033232320030021103233332300123110201010031",
+                         "+",
+                         "BBA!>AA,B>;;=A%39%B8====>0?-?%9A2<)3?(4*36%A%4&+9%")
+        self.assertTrue(read.is_colorspace)
+
+    def test_equality(self):
+        """
+        FastqRead: handle equality operator ('==')
+        """
+        readn1_data = """@73D9FA:3:FC:1:1:7507:1000 1:N:0:
+NACAACCTGATTAGCGGCGTTGACAGATGTATCCAT
++
+#))))55445@@@@@C@@@@@@@@@:::::<<:::<"""
+        readn1 = FastqRead(*readn1_data.split('\n'))
+        readn2 = FastqRead(*readn1_data.split('\n'))
+        readn3_data = """@73D9FA:3:FC:1:1:7507:1000 2:N:0:
+NACAACCTGATTAGCGGCGTTGACAGATGTATCCAT
++
+#))))55445@@@@@C@@@@@@@@@:::::<<:::<"""
+        readn3 = FastqRead(*readn3_data.split('\n'))
+        self.assertTrue(readn1 == readn2)
+        self.assertTrue(readn1 == readn1_data)
+        self.assertFalse(readn1 == readn3)
+        self.assertFalse(readn1 == readn3_data)
+
+
+class TestSequenceIdentifier(unittest.TestCase):
+    """
+    Tests of the SequenceIdentifier class
+    """
+
+    def test_read_illumina18_id(self):
+        """
+        SequenceIdentifier: process 'illumina18'-style sequence identifier
+        """
+        seqid_string = "@EAS139:136:FC706VJ:2:2104:15343:197393 1:Y:18:ATCACG"
+        seqid = SequenceIdentifier(seqid_string)
+        # Check we get back what we put in
+        self.assertEqual(str(seqid),seqid_string)
+        # Check the format
+        self.assertEqual('illumina18',seqid.format)
+        # Check attributes were correctly extracted
+        self.assertEqual('EAS139',seqid.instrument_name)
+        self.assertEqual('136',seqid.run_id)
+        self.assertEqual('FC706VJ',seqid.flowcell_id)
+        self.assertEqual('2',seqid.flowcell_lane)
+        self.assertEqual('2104',seqid.tile_no)
+        self.assertEqual('15343',seqid.x_coord)
+        self.assertEqual('197393',seqid.y_coord)
+        self.assertEqual('1',seqid.pair_id)
+        self.assertEqual('Y',seqid.bad_read)
+        self.assertEqual('18',seqid.control_bit_flag)
+        self.assertEqual('ATCACG',seqid.index_sequence)
+
+    def test_read_illumina18_id_no_index_sequence(self):
+        """
+        SequenceIdentifier: process an 'illumina18'-style sequence id with no index sequence (barcode)
+        """
+        seqid_string = "@73D9FA:3:FC:1:1:7507:1000 1:N:0:"
+        seqid = SequenceIdentifier(seqid_string)
+        # Check we get back what we put in
+        self.assertEqual(str(seqid),seqid_string)
+        # Check the format
+        self.assertEqual('illumina18',seqid.format)
+        # Check attributes were correctly extracted
+        self.assertEqual('73D9FA',seqid.instrument_name)
+        self.assertEqual('3',seqid.run_id)
+        self.assertEqual('FC',seqid.flowcell_id)
+        self.assertEqual('1',seqid.flowcell_lane)
+        self.assertEqual('1',seqid.tile_no)
+        self.assertEqual('7507',seqid.x_coord)
+        self.assertEqual('1000',seqid.y_coord)
+        self.assertEqual('1',seqid.pair_id)
+        self.assertEqual('N',seqid.bad_read)
+        self.assertEqual('0',seqid.control_bit_flag)
+        self.assertEqual('',seqid.index_sequence)
+
+    def test_read_illumina_id(self):
+        """
+        SequenceIdentifier: process an 'illumina'-style sequence identifier
+        """
+        seqid_string = "@HWUSI-EAS100R:6:73:941:1973#0/1"
+        seqid = SequenceIdentifier(seqid_string)
+        # Check we get back what we put in
+        self.assertEqual(str(seqid),seqid_string)
+        # Check the format
+        self.assertEqual('illumina',seqid.format)
+        # Check attributes were correctly extracted
+        self.assertEqual('HWUSI-EAS100R',seqid.instrument_name)
+        self.assertEqual('6',seqid.flowcell_lane)
+        self.assertEqual('73',seqid.tile_no)
+        self.assertEqual('941',seqid.x_coord)
+        self.assertEqual('1973',seqid.y_coord)
+        self.assertEqual('0',seqid.multiplex_index_no)
+        self.assertEqual('1',seqid.pair_id)
+
+    def test_read_illumina18_id_fastq_screen_tags(self):
+        """
+        SequenceIdentifier: process an 'illumina18'-style sequence id with 'fastq_screen' tags
+        """
+        # Format for first read in a tagged FASTQ
+        seqid_string = "@NB500968:70:HCYMKBGX2:1:11101:22672:1659 2:N:0:1#FQST:Human:Mouse:01"
+        seqid = SequenceIdentifier(seqid_string)
+        # Check we get back what we put in
+        self.assertEqual(str(seqid),seqid_string)
+        # Check the format
+        self.assertEqual('illumina18',seqid.format)
+        # Check attributes were correctly extracted
+        self.assertEqual('NB500968',seqid.instrument_name)
+        self.assertEqual('70',seqid.run_id)
+        self.assertEqual('HCYMKBGX2',seqid.flowcell_id)
+        self.assertEqual('1',seqid.flowcell_lane)
+        self.assertEqual('11101',seqid.tile_no)
+        self.assertEqual('22672',seqid.x_coord)
+        self.assertEqual('1659',seqid.y_coord)
+        self.assertEqual('2',seqid.pair_id)
+        self.assertEqual('N',seqid.bad_read)
+        self.assertEqual('0',seqid.control_bit_flag)
+        self.assertEqual('1#FQST:Human:Mouse:01',seqid.index_sequence)
+        # Format of second and subsequent read IDs
+        seqid_string = "@NB500968:70:HCYMKBGX2:1:11101:24365:2047 2:N:0:1#FQST:22"
+        seqid = SequenceIdentifier(seqid_string)
+        # Check we get back what we put in
+        self.assertEqual(str(seqid),seqid_string)
+        # Check the format
+        self.assertEqual('illumina18',seqid.format)
+        # Check attributes were correctly extracted
+        self.assertEqual('NB500968',seqid.instrument_name)
+        self.assertEqual('70',seqid.run_id)
+        self.assertEqual('HCYMKBGX2',seqid.flowcell_id)
+        self.assertEqual('1',seqid.flowcell_lane)
+        self.assertEqual('11101',seqid.tile_no)
+        self.assertEqual('24365',seqid.x_coord)
+        self.assertEqual('2047',seqid.y_coord)
+        self.assertEqual('2',seqid.pair_id)
+        self.assertEqual('N',seqid.bad_read)
+        self.assertEqual('0',seqid.control_bit_flag)
+        self.assertEqual('1#FQST:22',seqid.index_sequence)
+
+    def test_unrecognised_id_format(self):
+        """
+        SequenceIdentifier: process unrecognised sequence identifier
+        """
+        seqid_string = "@SEQID"
+        seqid = SequenceIdentifier(seqid_string)
+        # Check we get back what we put in
+        self.assertEqual(str(seqid),seqid_string)
+        # Check the format
+        self.assertEqual(None, seqid.format)
+
+    def test_is_pair_of(self):
+        """
+        SequenceIdentifier: check sequence identifier pairing
+        """
+        seqid1 = "@HWI-700511R:183:D2C8UACXX:1:1101:1115:2123 1:N:0:GCCAAT"
+        seqid2 = "@HWI-700511R:183:D2C8UACXX:1:1101:1115:2123 2:N:0:GCCAAT"
+        seqid3 = "@HWI-700511R:183:D2C8UACXX:5:1101:1496:2199 2:N:0:GCCAAT"
+        self.assertTrue(SequenceIdentifier(seqid1).is_pair_of(SequenceIdentifier(seqid2)))
+        self.assertTrue(SequenceIdentifier(seqid2).is_pair_of(SequenceIdentifier(seqid1)))
+        self.assertFalse(SequenceIdentifier(seqid1).is_pair_of(SequenceIdentifier(seqid1)))
+        self.assertFalse(SequenceIdentifier(seqid2).is_pair_of(SequenceIdentifier(seqid2)))
+        self.assertFalse(SequenceIdentifier(seqid1).is_pair_of(SequenceIdentifier(seqid1)))
+        self.assertFalse(SequenceIdentifier(seqid3).is_pair_of(SequenceIdentifier(seqid1)))
+
+    def test_handle_r1_r2_r3_pair_id(self):
+        """
+        SequenceIdentifier: check that R1/R2/R3 sequence identifiers have correct pair ID
+        """
+        seqid1 = "@HWI-700511R:183:D2C8UACXX:1:1101:1115:2123 1:N:0:GCCAAT"
+        seqid2 = "@HWI-700511R:183:D2C8UACXX:1:1101:1115:2123 2:N:0:GCCAAT"
+        seqid3 = "@HWI-700511R:183:D2C8UACXX:1:1101:1115:2123 3:N:0:GCCAAT"
+        self.assertEqual(SequenceIdentifier(seqid1).pair_id, "1")
+        self.assertEqual(SequenceIdentifier(seqid2).pair_id, "2")
+        self.assertEqual(SequenceIdentifier(seqid3).pair_id, "3")
+
+
+class TestFastqAttributes(unittest.TestCase):
+    """
+    Tests of the FastqAttributes class
+    """
+
+    def test_fastq_attributes_nreads(self):
+        """
+        FastqAttributes: check number of reads
+        """
+        fp = StringIO(FASTQ_DATA_R1)
+        attrs = FastqAttributes(fp=fp)
+        self.assertEqual(attrs.nreads,5)
+
+class TestNReads(unittest.TestCase):
+    """
+    Tests of the nreads function
+    """
+    def setUp(self):
+        # Temporary working dir
+        self.wd = tempfile.mkdtemp(suffix='.TestNReads')
+
+    def tearDown(self):
+        # Remove temporary working dir
+        if os.path.isdir(self.wd):
+            shutil.rmtree(self.wd)
+
+    def test_nreads(self):
+        """
+        nreads: check that nreads returns correct read count
+        """
+        fp = StringIO(FASTQ_DATA_R1)
+        self.assertEqual(nreads(fp=fp),5)
+
+    def test_nreads_from_file_on_disk(self):
+        """
+        nreads: check nreads from FASTQ on disk
+        """
+        self.fastq_in = os.path.join(self.wd,'test.fq')
+        with open(self.fastq_in,'w') as fp:
+            fp.write(FASTQ_DATA_R1)
+        self.assertEqual(nreads(self.fastq_in),5)
+
+    def test_nreads_from_gzipped_file_on_disk(self):
+        """
+        nreads: check nreads from gzipped FASTQ on disk
+        """
+        self.fastq_in = os.path.join(self.wd,'test.fq.gz')
+        with gzip.open(self.fastq_in,'wt') as fp:
+            fp.write(FASTQ_DATA_R1)
+        self.assertEqual(nreads(self.fastq_in),5)
+
+
+class TestFastqsArePair(unittest.TestCase):
+    """
+    Tests of the fastqs_are_pair function
+    """
+
+    def test_fastqs_are_pair(self):
+        """
+        fastqs_are_pair: recognises FASTQ pairing
+        """
+        fp1 = StringIO(FASTQ_DATA_R1)
+        fp2 = StringIO(FASTQ_DATA_R2)
+        self.assertTrue(fastqs_are_pair(fp1=fp1,fp2=fp2,verbose=False))

--- a/bcftbx/test/io/test_fastq.py
+++ b/bcftbx/test/io/test_fastq.py
@@ -418,58 +418,6 @@ class TestSequenceIdentifier(unittest.TestCase):
         self.assertEqual(SequenceIdentifier(seqid3).pair_id, "3")
 
 
-class TestFastqAttributes(unittest.TestCase):
-    """
-    Tests of the FastqAttributes class
-    """
-
-    def test_fastq_attributes_nreads(self):
-        """
-        FastqAttributes: check number of reads
-        """
-        fp = StringIO(FASTQ_DATA_R1)
-        attrs = FastqAttributes(fp=fp)
-        self.assertEqual(attrs.nreads,5)
-
-class TestNReads(unittest.TestCase):
-    """
-    Tests of the nreads function
-    """
-    def setUp(self):
-        # Temporary working dir
-        self.wd = tempfile.mkdtemp(suffix='.TestNReads')
-
-    def tearDown(self):
-        # Remove temporary working dir
-        if os.path.isdir(self.wd):
-            shutil.rmtree(self.wd)
-
-    def test_nreads(self):
-        """
-        nreads: check that nreads returns correct read count
-        """
-        fp = StringIO(FASTQ_DATA_R1)
-        self.assertEqual(nreads(fp=fp),5)
-
-    def test_nreads_from_file_on_disk(self):
-        """
-        nreads: check nreads from FASTQ on disk
-        """
-        self.fastq_in = os.path.join(self.wd,'test.fq')
-        with open(self.fastq_in,'w') as fp:
-            fp.write(FASTQ_DATA_R1)
-        self.assertEqual(nreads(self.fastq_in),5)
-
-    def test_nreads_from_gzipped_file_on_disk(self):
-        """
-        nreads: check nreads from gzipped FASTQ on disk
-        """
-        self.fastq_in = os.path.join(self.wd,'test.fq.gz')
-        with gzip.open(self.fastq_in,'wt') as fp:
-            fp.write(FASTQ_DATA_R1)
-        self.assertEqual(nreads(self.fastq_in),5)
-
-
 class TestFastqsArePair(unittest.TestCase):
     """
     Tests of the fastqs_are_pair function

--- a/bcftbx/test/io/test_fastq.py
+++ b/bcftbx/test/io/test_fastq.py
@@ -12,8 +12,7 @@ from io import StringIO
 from bcftbx.io.fastq import FastqIterator
 from bcftbx.io.fastq import FastqRead
 from bcftbx.io.fastq import SequenceIdentifier
-from bcftbx.io.fastq import FastqAttributes
-from bcftbx.io.fastq import nreads
+from bcftbx.io.fastq import count_reads
 from bcftbx.io.fastq import fastqs_are_pair
 
 
@@ -416,6 +415,19 @@ class TestSequenceIdentifier(unittest.TestCase):
         self.assertEqual(SequenceIdentifier(seqid1).pair_id, "1")
         self.assertEqual(SequenceIdentifier(seqid2).pair_id, "2")
         self.assertEqual(SequenceIdentifier(seqid3).pair_id, "3")
+
+
+class TestCountReads(unittest.TestCase):
+    """
+    Tests of the 'count_reads' function
+    """
+
+    def test_count_reads(self):
+        """
+        count_reads: count reads in FASTQ
+        """
+        fp = StringIO(FASTQ_DATA_R1)
+        self.assertEqual(count_reads(fp=fp), 5)
 
 
 class TestFastqsArePair(unittest.TestCase):

--- a/bcftbx/test/test_FASTQFile.py
+++ b/bcftbx/test/test_FASTQFile.py
@@ -8,6 +8,7 @@ import os
 import tempfile
 import shutil
 import gzip
+import logging
 
 fastq_data = u"""@73D9FA:3:FC:1:1:7507:1000 1:N:0:
 NACAACCTGATTAGCGGCGTTGACAGATGTATCCAT

--- a/bcftbx/test/test_FASTQFile.py
+++ b/bcftbx/test/test_FASTQFile.py
@@ -1,7 +1,6 @@
 #######################################################################
 # Tests for FASTQFile.py module
 #######################################################################
-from builtins import str
 from bcftbx.FASTQFile import *
 import unittest
 import io
@@ -190,7 +189,7 @@ class TestFastqRead(unittest.TestCase):
         read = FastqRead(seqid,seq,optid,quality)
         self.assertTrue(isinstance(read.seqid,SequenceIdentifier))
         self.assertEqual(str(read.seqid),seqid.rstrip('\n'))
-        self.assertEqual(read.raw_seqid,seqid)
+        self.assertEqual(read.raw_seqid,seqid.rstrip('\n'))
         self.assertEqual(read.sequence,seq.rstrip('\n'))
         self.assertEqual(read.optid,optid.rstrip('\n'))
         self.assertEqual(read.quality,quality.rstrip('\n'))


### PR DESCRIPTION
Refactors the code from the `bcftbx.FASTQFile` module into a new `bcftbx.io.fastq` module.

This reimplements the `FastqIterator`, `FastqRead` and `SequencerIdentifier` classes within the `bcftbx.io.fastq` module with modified interfaces, and renames the `nreads` function as `count_reads`. Other functions are essentially copied as-is. 

Note that the `FastqAttributes` class has not been implemented in the new module.

The legacy classes and functions in `bcftbx.FASTQFile` have then been reimplemented where appropriated using the new versions from `bcftbx.io.fastq`.

This is part of the refactoring work outlined in issue #33.