### PR TITLE
Refactor 'fasta' module into 'io.fasta'

### DIFF
--- a/bcftbx/cli/split_fasta.py
+++ b/bcftbx/cli/split_fasta.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     split_fasta.py: extract individual chromosome sequences from fasta file
-#     Copyright (C) University of Manchester 2013-2022 Peter Briggs
+#     Copyright (C) University of Manchester 2013-2026 Peter Briggs
 #
 
 """
@@ -19,8 +19,7 @@ import sys
 import os
 import io
 import argparse
-import logging
-from ..fasta import FastaChromIterator
+from ..io.fasta import FastaChromIterator
 from .. import get_version
 
 #######################################################################
@@ -62,5 +61,5 @@ def main():
         print("Outputting '%s' to %s" % (name,fasta))
         if os.path.isfile(fasta):
             sys.stderr.write("WARNING '%s' already exists, overwriting\n" % fasta)
-        with io.open(fasta,'wt') as fp:
+        with open(fasta,'wt') as fp:
             fp.write(">%s\n%s\n" % (name,seq))

--- a/bcftbx/fasta.py
+++ b/bcftbx/fasta.py
@@ -1,103 +1,23 @@
 #!/usr/bin/env python
 #
 #     fasta.py: classes and functions for handling FASTA files
-#     Copyright (C) University of Manchester 2022 Peter Briggs
+#     Copyright (C) University of Manchester 2022-2026 Peter Briggs
 #
+
+"""
+Legacy module providing utilities for reading through FASTA files.
+
+The core functionality has been reimplemented in the ``io.fasta`` module;
+the code in this module is now deprecated and only maintained for
+backwards compatibility; they will be removed in a future release.
+
+The legacy classes and functions are:
+
+* FastaChromIterator: enables looping through chromosomes in FASTA file
+"""
 
 #######################################################################
 # Import modules
 #######################################################################
 
-import io
-from collections.abc import Iterator
-
-#######################################################################
-# Classes
-#######################################################################
-
-class FastaChromIterator(Iterator):
-    """
-    Class to loop over all chromosomes in a FASTA file, returning a
-    tuple of the form
-
-    (name,seq)
-
-    for each chromosome (where 'name' is the chromosome name given
-    in the '>' record, and 'seq' is the associated sequence).
-
-    Example looping over all chromosomes and echoing to stdout:
-
-    >>> for chrom in FastaChromIterator(fasta_file):
-    >>>    print(">%s\n%s" % (chrom[0],chrom[1]))
-
-    The input source can be specified either as a file name or
-    as a file-like object opened for line reading.
-
-    Note that newlines within sequence records are preserved,
-    however trailing newlines are removed.
-
-    Arguments:
-      fasta: name of the Fasta file to iterate through
-      fp: file-like object to read Fasta data from
-    """
-
-    def __init__(self,fasta=None,fp=None):
-        """
-        Create a new FastaChromIterator
-        """
-        if fp is None:
-            # Open input fasta file
-            self._fasta = fasta
-            self._fp = io.open(self._fasta,'rt')
-        else:
-            # File object already supplied
-            self._fasta = None
-            self._fp = fp
-        # Internal: store last line read from file
-        self._line = None
-
-    def _sanitise_sequence(self,seqs):
-        """
-        Internal: join list of sequences for output
-        """
-        return ''.join(seqs).rstrip('\n')
-
-    def __next__(self):
-        """
-        Return next chromosome from Fasta file as a (name,sequence) tuple
-        """
-        # Initialise line storage
-        if self._line is None:
-            line = self._fp.readline()
-        else:
-            line = self._line
-        chrom = None
-        seq = []
-        # Loop over lines in file looking for start of chromosome
-        while line != '':
-            if line.startswith(">"):
-                if chrom is None:
-                    # Start of current chromosome, get name
-                    chrom = line.strip()[1:]
-                else:
-                    # Start of next chromosome, finish
-                    # Store line for next iteration
-                    self._line = line
-                    # Return data
-                    return (chrom,self._sanitise_sequence(seq))
-            elif chrom is not None:
-                # Store sequence line
-                seq.append(line)
-            # Get next line
-            line = self._fp.readline()
-        # Reached end of file
-        if chrom is not None:
-            # Close input file?
-            if self._fasta is not None:
-                self._fp.close()
-            # Flush remaining data
-            self._line = ''
-            return (chrom,self._sanitise_sequence(seq))
-        else:
-            # Finished iteration
-            raise StopIteration
+from .io.fasta import FastaChromIterator

--- a/bcftbx/io/fasta.py
+++ b/bcftbx/io/fasta.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+#
+#     fasta.py: classes and utilities for handling FASTA files
+#     Copyright (C) University of Manchester 2026 Peter Briggs
+#
+
+
+"""
+Classes for reading FASTQ files and manipulating the data within them:
+
+* FastaChromIterator: enables looping through chromosomes in FASTA file
+"""
+
+
+from collections.abc import Iterator
+
+
+class FastaChromIterator(Iterator):
+    """
+    Class to loop over chromosomes in a FASTA file
+
+    Implements an iterator which can be used to loop through the
+    chromosome records in a FASTA-format file.
+
+    For each record it returns a tuple of the form:
+
+    (name, seq)
+
+    for each chromosome, where 'name' is the chromosome name
+    (given in the '>' record), and 'seq' is the associated sequence.
+
+    Note that newlines within multiline sequence records are
+    preserved, however trailing newlines are removed.
+
+    Example looping over all chromosomes and echoing to stdout:
+
+    >>> for chrom, sequence in FastaChromIterator(fasta_file):
+    ...     print(f">{chrom}\n{sequence}")
+
+    The input source can be specified either as a file name or
+    as a file-like object opened for line reading.
+
+    Arguments:
+      fasta (str): name of the Fasta file to iterate through
+      fp (any): file-like object to read Fasta data from
+    """
+    def __init__(self, fasta=None, fp=None):
+        """
+        Create a new FastaChromIterator
+        """
+        if fp is None:
+            # Open input fasta file
+            self._fasta = fasta
+            self._fp = open(self._fasta, "rt")
+        else:
+            # File object already supplied
+            self._fasta = None
+            self._fp = fp
+        # Internal: store last line read from file
+        self._line = None
+
+    @staticmethod
+    def _sanitise_sequence(seqs):
+        """
+        Internal: join list of sequences for output
+        """
+        return "".join(seqs).rstrip("\n")
+
+    def __next__(self):
+        """
+        Return next chromosome from Fasta file as a (name,sequence) tuple
+        """
+        # Initialise line storage
+        if self._line is None:
+            line = self._fp.readline()
+        else:
+            line = self._line
+        chrom = None
+        seq = []
+        # Loop over lines in file looking for start of chromosome
+        while line != "":
+            if line.startswith(">"):
+                if chrom is None:
+                    # Start of current chromosome, get name
+                    chrom = line.strip()[1:]
+                else:
+                    # Start of next chromosome, finish
+                    # Store line for next iteration
+                    self._line = line
+                    # Return data
+                    return chrom, self._sanitise_sequence(seq)
+            elif chrom is not None:
+                # Store sequence line
+                seq.append(line)
+            # Get next line
+            line = self._fp.readline()
+        # Reached end of file
+        if chrom is not None:
+            # Close input file?
+            if self._fasta is not None:
+                self._fp.close()
+            # Flush remaining data
+            self._line = ""
+            return chrom, self._sanitise_sequence(seq)
+        else:
+            # Finished iteration
+            raise StopIteration

--- a/bcftbx/test/io/test_fasta.py
+++ b/bcftbx/test/io/test_fasta.py
@@ -1,0 +1,39 @@
+#######################################################################
+# Tests for io.fasta.py module
+#######################################################################
+
+
+import unittest
+from io import StringIO
+from bcftbx.fasta import FastaChromIterator
+
+
+# Test data
+FASTA_DATA = """>chr2L
+Cgacaatgcacgacagagga
+agcagCTCAAGATAccttct
+>chr2R
+CTCAAGATAccttctacaga
+Cgacaatgcacgacagagga
+"""
+
+
+class TestFastaChromIterator(unittest.TestCase):
+    """
+    Tests of the FastaChromIterator class
+    """
+    def test_fastachromiterator(self):
+        """
+        FastaChromIterator: iteration over small FASTA file
+        """
+        fp = StringIO(FASTA_DATA)
+        fasta = FastaChromIterator(fp=fp)
+        expected = (
+            ("chr2L", "Cgacaatgcacgacagagga\nagcagCTCAAGATAccttct"),
+            ("chr2R", "CTCAAGATAccttctacaga\nCgacaatgcacgacagagga"),
+        )
+        nchroms = 0
+        for chrom,expt in zip(fasta,expected):
+            nchroms += 1
+            self.assertEqual(chrom,expt)
+        self.assertEqual(nchroms, len(expected))

--- a/bcftbx/test/test_fasta.py
+++ b/bcftbx/test/test_fasta.py
@@ -3,6 +3,7 @@
 #######################################################################
 
 from bcftbx.fasta import *
+from io import StringIO
 import unittest
 
 fasta_data = """>chr2L
@@ -22,7 +23,7 @@ class TestFastaChromIterator(unittest.TestCase):
         """
         FastaChromIterator: iteration over small FASTA file
         """
-        fp = io.StringIO(fasta_data)
+        fp = StringIO(fasta_data)
         fasta = FastaChromIterator(fp=fp)
         expected = (
             ("chr2L","Cgacaatgcacgacagagga\nagcagCTCAAGATAccttct"),


### PR DESCRIPTION
Moves the code (essentially a single class `FastaChromIterator`) from `bcftbx.fasta` into a new submodule `bcftbx.io.fasta`, as part of the package refactoring tracked within issue #33.

Also updates the `split_fasta.py` CLI utility to use the new submodule.

The `bcftbx.fasta` module is retained as a legacy wrapper to be removed in a future release.