### PR TITLE
Update Slurm job runner to handle unavailable controller

### DIFF
--- a/bcftbx/jobs/runners.py
+++ b/bcftbx/jobs/runners.py
@@ -1679,33 +1679,12 @@ exit $exit_code
             sbatch.extend(self.slurm_extra_args)
         sbatch.append(job_script)
         logger.debug("SlurmRunner: sbatch command: %s" % sbatch)
-        # Run the sbatch job in the current directory
-        cwd = os.getcwd()
-        if not os.path.exists(cwd):
-            logger.error("SlurmRunner: cwd doesn't exist!")
-            return None
-        logger.debug("SlurmRunner: executing in %s" % cwd)
-        p = subprocess.Popen(sbatch, cwd=cwd,
-                             stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE,
-                             universal_newlines=True)
-        stdoutdata, stderrdata = p.communicate()
-        logger.debug(f"SlurmRunner: sbatch output: {stdoutdata}")
-        logger.debug(f"SlurmRunner: sbatch error: {stderrdata}")
-        # Check stderr to try and detect error with submission
-        error = stderrdata.strip()
-        if error:
-            # Just echo error message as a warning
-            logger.warning("SlurmRunner: '%s'" % error)
-        # Capture the job id from the output
-        job_id = None
-        for line in stdoutdata.split('\n'):
-            if line.startswith("Submitted batch job"):
-                job_id = line.split()[-1]
-        if job_id is None:
-            logger.error("SlurmRunner: failed to get job ID from "
-                         "sbatch output: %r" % stdoutdata)
-        logger.debug(f"SlurmRunner: done - job id = {job_id}")
+        # Run the sbatch job
+        try:
+            job_id = self._run_sbatch(sbatch)
+        except SlurmException as ex:
+            logger.error(f"SlurmRunner: {ex}")
+            job_id = None
         # Store internal number, name and log dir against job id
         if job_id is not None:
             self._job_number[job_id] = job_number
@@ -1937,7 +1916,12 @@ exit $exit_code
             removed.
         """
         updated_job_list = []
-        squeue_jobs = [j[0] for j in self._run_squeue()]
+        try:
+            squeue_jobs = [j[0] for j in self._run_squeue()]
+        except SlurmException:
+            logger.debug("SlurmRunner: failed to run squeue (Slurm error?)")
+            # FIXME could also flag that Slurm itself appears to be in an error state
+            return [job_id for job_id in job_list]
         for job_id in job_list:
             if job_id not in squeue_jobs:
                 logger.debug(f"SlurmRunner: job {job_id} has gone away?")
@@ -2047,6 +2031,43 @@ exit $exit_code
         # Remove the internally stored job number
         del(self._job_number[job_id])
 
+    def _run_sbatch(self, sbatch_cmd):
+        """
+        Internal: run sbatch command
+        """
+        # Run the sbatch job in the current directory
+        cwd = os.getcwd()
+        if not os.path.exists(cwd):
+            logger.error("SlurmRunner: cwd doesn't exist!")
+            return None
+        logger.debug("SlurmRunner: executing in %s" % cwd)
+        p = subprocess.Popen(sbatch_cmd, cwd=cwd,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE,
+                             universal_newlines=True)
+        stdoutdata, stderrdata = p.communicate()
+        logger.debug(f"SlurmRunner: sbatch output: {stdoutdata}")
+        logger.debug(f"SlurmRunner: sbatch error: {stderrdata}")
+        # Handle output and extrract job ID
+        job_id = None
+        # Check stderr to try and detect error with submission
+        error = stderrdata.strip()
+        if error:
+            # Just echo error message as a warning
+            logger.warning("SlurmRunner: '%s'" % error)
+        else:
+            # Capture the job id from the output
+            for line in stdoutdata.split('\n'):
+                if line.startswith("Submitted batch job"):
+                    job_id = line.split()[-1]
+            logger.debug(f"SlurmRunner: done - job id = {job_id}")
+        if job_id is None:
+            logger.error("SlurmRunner: failed to get job ID from "
+                         "sbatch output: %r" % stdoutdata)
+            raise SlurmException("'sbatch' job submission failed (Slurm error?)")
+        else:
+            return job_id
+
     def _run_squeue(self):
         """
         Internal: run squeue and return data as a list of lists
@@ -2082,9 +2103,18 @@ exit $exit_code
         # Output has a header line with field names then one
         # line per job
         lines = stdoutdata.rstrip("\n").split("\n")
-        fields = lines[0].split()
-        idx_jobid = fields.index("JOBID")
-        idx_state = fields.index("ST")
+        try:
+            fields = lines[0].split()
+        except Exception as ex:
+            logger.debug(f"SlurmRunner: 'squeue' output is empty")
+            raise SlurmException("'squeue' output is empty")
+        try:
+            idx_jobid = fields.index("JOBID")
+            idx_state = fields.index("ST")
+        except ValueError:
+            logger.debug(f"SlurmRunner: 'squeue' output header doesn't contain "
+                         f"expected fields")
+            raise SlurmException("unexpected header from 'squeue': {lines[0]}")
         for line in lines[1:]:
             # Store tuples of jobid, state
             data = line.split()
@@ -2182,6 +2212,12 @@ exit $exit_code
                 new_args.append(arg)
         # Update the extra arguments
         self._slurm_extra_args = new_args
+
+
+class SlurmException(Exception):
+    """
+    Class for errors from Slurm job submission system
+    """
 
 
 class ResourceLock:

--- a/bcftbx/mockslurm.py
+++ b/bcftbx/mockslurm.py
@@ -1,5 +1,5 @@
 #     mockslurm.py: mock Slurm functionality for testing
-#     Copyright (C) University of Manchester 2025 Peter Briggs
+#     Copyright (C) University of Manchester 2025-2026 Peter Briggs
 #
 #######################################################################
 
@@ -53,6 +53,11 @@ class MockSlurm:
     NB the 'stop' method should be invoked on the 'MockSlurm'
     instance when it is not longer needed, to ensure that any
     running processes are properly terminated.
+
+    Errors with the Slurm controller can be mimicked using the
+    'set_slurm_error_state' method, which blocks the normal
+    behaviour of the 'sbatch' etc commands. The mock error state
+    can be cleared using the 'clear_slurm_error_state' method.
 
     Arguments:
       max_jobs (int): maximum number of jobs to run at
@@ -110,33 +115,52 @@ class MockSlurm:
         """
         Set up the persistent database
         """
+        sql_tables = [
+            # State of the Slurm controller
+            """
+            CREATE TABLE controller (
+              id            INTEGER PRIMARY KEY,
+              error_state   INTEGER,
+              error_message VARCHAR
+            )
+            """,
+            # Jobs
+            """
+            CREATE TABLE jobs (
+              id          INTEGER PRIMARY KEY,
+              user        CHAR,
+              state       CHAR,
+              name        VARCHAR,
+              command     VARCHAR,
+              working_dir VARCHAR,
+              nslots      INTEGER,
+              partition   VARCHAR,
+              output_tmpl CHAR,
+              error_tmpl  CHAR,
+              export      CHAR,
+              pid         INTEGER,
+              sbatch_time FLOAT,
+              start_time  FLOAT,
+              end_time    FLOAT,
+              exit_code   INTEGER
+            )
+            """
+        ]
+        for sql in sql_tables:
+            try:
+                cu = self._cx.cursor()
+                cu.execute(sql)
+            except sqlite3.Error as ex:
+                print("Failed to set up database: %s" % ex)
+                raise ex
+        # Set initial state of controller
         sql = """
-        CREATE TABLE jobs (
-          id          INTEGER PRIMARY KEY,
-          user        CHAR,
-          state       CHAR,
-          name        VARCHAR,
-          command     VARCHAR,
-          working_dir VARCHAR,
-          nslots      INTEGER,
-          partition   VARCHAR,
-          output_tmpl CHAR,
-          error_tmpl  CHAR,
-          export      CHAR,
-          pid         INTEGER,
-          sbatch_time FLOAT,
-          start_time  FLOAT,
-          end_time    FLOAT,
-          exit_code   INTEGER
-        )
+        INSERT INTO controller (id,error_state,error_message) VALUES (?, ?, ?)
         """
-        try:
-            cu = self._cx.cursor()
-            cu.execute(sql)
-            self._cx.commit()
-        except sqlite3.Error as ex:
-            print("Failed to set up database: %s" % ex)
-            raise ex
+        cu = self._cx.cursor()
+        cu.execute(sql, (0, 0, ""))
+        # Commit changes
+        self._cx.commit()
 
     def _init_job(self, name, command, working_dir, nslots, partition,
                   output_tmpl, error_tmpl, export):
@@ -375,6 +399,43 @@ echo "$exit_code" 1>%s/__exit_code.%d
             else:
                 break
 
+    def set_slurm_error_state(self, message):
+        """
+        Puts the mock Slurm instance into an error state
+
+        When in an error state, commands will issue the supplied message
+        and exit with status 1 without performing the requested action
+        """
+        sql = """
+        UPDATE controller set error_state=?,error_message=? WHERE id==0
+        """
+        cu = self._cx.cursor()
+        cu.execute(sql, (1, str(message)))
+        self._cx.commit()
+
+    def get_slurm_error_state(self):
+        """
+        Retrieve the error state and associated message
+        """
+        sql = """
+        SELECT error_state,error_message FROM controller WHERE id=0
+        """
+        cu = self._cx.cursor()
+        cu.execute(sql)
+        error_state_info = cu.fetchone()
+        return bool(int(error_state_info["error_state"])), error_state_info["error_message"]
+
+    def clear_slurm_error_state(self):
+        """
+        Removes the mock Slurm instance from an error state
+        """
+        sql = """
+        UPDATE controller set error_state=?,error_message=? WHERE id==0
+        """
+        cu = self._cx.cursor()
+        cu.execute(sql, (0, str("")))
+        self._cx.commit()
+
     def _list_jobs(self, user, state=None):
         """
         Get list of the jobs
@@ -481,6 +542,11 @@ echo "$exit_code" 1>%s/__exit_code.%d
         p.add_argument("--export", action="store", default="ALL")
         p.add_argument("--chdir", action="store")
         args,cmd = p.parse_known_args(argv)
+        # Check for error state
+        error_state, error_message = self.get_slurm_error_state()
+        if error_state:
+            print(error_message)
+            return
         # Command
         logging.debug(f"sbatch: cmd: {cmd}")
         if len(cmd) == 1:
@@ -561,6 +627,11 @@ echo "$exit_code" 1>%s/__exit_code.%d
             user = self._user()
         else:
             user = args.user
+        # Check for error state
+        error_state, error_message = self.get_slurm_error_state()
+        if error_state:
+            print(error_message)
+            return
         # Get jobs
         jobs = self._list_jobs(user=user)
         # Print header even if there are no jobs to report
@@ -611,6 +682,11 @@ echo "$exit_code" 1>%s/__exit_code.%d
         p.add_argument("-v", dest="verbose", action="store_true")
         p.add_argument("job_id",action="store",nargs="+")
         args = p.parse_args(argv)
+        # Check for error state
+        error_state, error_message = self.get_slurm_error_state()
+        if error_state:
+            print(error_message)
+            return
         # Loop over job ids
         for job_id in args.job_id:
             job_id = int(job_id)

--- a/bcftbx/test/jobs/test_runners.py
+++ b/bcftbx/test/jobs/test_runners.py
@@ -1025,8 +1025,111 @@ class TestSlurmRunner(unittest.TestCase):
                         "Stderr file '%s': not a file" %
                         runner.err_file(jobid3))
 
+    def test_slurm_runner_controller_unavailable_fail_to_submit_job(self):
+        """
+        Test SlurmRunner handles job submission when controller is not available
+        """
+        # Create a runner
+        runner = SlurmRunner()
+        self.assertEqual(runner.nslots, 1)
+        self.assertEqual(runner.partition, None)
+        self.assertFalse(runner.join_logs)
+        # Put Slurm into error state
+        self.mock_slurm.set_slurm_error_state(
+            "slurm_load_jobs error: Unable to contact slurm controller (connect failure)")
+        # Execute sleep command
+        jobid = self._run_job(runner,
+                             "slurm_test",
+                              self.working_dir,
+                             'sleep', ('5',))
+        self.assertEqual(jobid, None)
+
+    def test_slurm_runner_controller_unavailable_job_completion(self):
+        """
+        Test SlurmRunner handles job completion when controller is unavailable
+        """
+        # Create a runner
+        runner = SlurmRunner()
+        self.assertEqual(runner.nslots, 1)
+        self.assertEqual(runner.partition, None)
+        self.assertFalse(runner.join_logs)
+        # Execute sleep command
+        jobid = self._run_job(runner,
+                             "slurm_test",
+                              self.working_dir,
+                             'sleep', ('10',))
+        # Put Slurm into error state
+        self.mock_slurm.set_slurm_error_state(
+            "slurm_load_jobs error: Unable to contact slurm controller (connect failure)")
+        time.sleep(5)
+        self.mock_slurm.update_jobs()
+        self.assertTrue(runner.is_running(jobid))
+        # Check job status
+        time.sleep(5)
+        self.mock_slurm.update_jobs()
+        self.assertTrue(runner.is_running(jobid))
+        # Wait for job to complete
+        self._wait_for_jobs(runner, jobid)
+        # Check outputs
+        self.assertEqual(runner.name(jobid),"slurm_test")
+        expected_log = os.path.join(self.working_dir, f"slurm_test.o{jobid}")
+        self.assertEqual(expected_log, runner.log_file(jobid))
+        self.assertTrue(os.path.isfile(runner.log_file(jobid)),
+                        "Stdout file '%s': not a file" %
+                        runner.log_file(jobid))
+        expected_err = os.path.join(self.working_dir, f"slurm_test.e{jobid}")
+        self.assertEqual(expected_err, runner.err_file(jobid))
+        self.assertTrue(os.path.isfile(runner.err_file(jobid)),
+                        "Stderr file '%s': not a file" %
+                        runner.err_file(jobid))
+        # Check exit status of completed job
+        self.assertEqual(runner.exit_status(jobid), 0)
+
+    def test_slurm_runner_controller_temporarily_unavailable_job_completion(self):
+        """
+        Test SlurmRunner handles job completion when controller is temporarily unavailable
+        """
+        # Create a runner
+        runner = SlurmRunner()
+        self.assertEqual(runner.nslots, 1)
+        self.assertEqual(runner.partition, None)
+        self.assertFalse(runner.join_logs)
+        # Execute sleep command
+        jobid = self._run_job(runner,
+                             "slurm_test",
+                              self.working_dir,
+                             'sleep', ('10',))
+        # Put Slurm into error state
+        self.mock_slurm.set_slurm_error_state(
+            "slurm_load_jobs error: Unable to contact slurm controller (connect failure)")
+        time.sleep(5)
+        self.mock_slurm.update_jobs()
+        self.assertTrue(runner.is_running(jobid))
+        # Check job status
+        time.sleep(5)
+        self.mock_slurm.update_jobs()
+        self.assertTrue(runner.is_running(jobid))
+        # Clear Slurm error state
+        self.mock_slurm.clear_slurm_error_state()
+        # Wait for job to complete
+        self._wait_for_jobs(runner, jobid)
+        # Check outputs
+        self.assertEqual(runner.name(jobid),"slurm_test")
+        expected_log = os.path.join(self.working_dir, f"slurm_test.o{jobid}")
+        self.assertEqual(expected_log, runner.log_file(jobid))
+        self.assertTrue(os.path.isfile(runner.log_file(jobid)),
+                        "Stdout file '%s': not a file" %
+                        runner.log_file(jobid))
+        expected_err = os.path.join(self.working_dir, f"slurm_test.e{jobid}")
+        self.assertEqual(expected_err, runner.err_file(jobid))
+        self.assertTrue(os.path.isfile(runner.err_file(jobid)),
+                        "Stderr file '%s': not a file" %
+                        runner.err_file(jobid))
+        # Check exit status of completed job
+        self.assertEqual(runner.exit_status(jobid), 0)
+
     @unittest.skip("don't know what error state looks like for Slurm")
-    def test_slurm_runner_error_state(self):
+    def test_slurm_runner_job_error_state(self):
         """
         Test SlurmRunner detects job in error state
         """


### PR DESCRIPTION
PR that attempts to address an issue with the Slurm job runner (`SlurmRunner` class in `bcftbx/jobs/runners`) when the Slurm controller can't be contacted.

**The problem**

When the Slurm controller becomes unavailable then (for example) running `squeue` on the system manually produces the following message:

    $ squeue
    slurm_load_jobs error: Unable to contact slurm controller (connect failure)

and no job information is output. Often this appears to be a temporary problem and contact with the controller is reestablished by the system,behind the scenes then the `squeue` command will give the expected output:

    $ squeue
          JOBID PRIORITY  PARTITION    NAME            USER     ST SUBMIT_TIME    START_TIME     TIME       TIME_LIMIT  NODES  CPUS NODELIST(REASON)

However in the meantime this puts the `SlurmRunner` into an unrecoverable error state.

(This was first observed in the `auto-process-ngs` package, see https://github.com/fls-bioinformatics-core/auto_process_ngs/issues/1182)

**Attempted solution**

The PR updates the `SlurmRunner` to recognise the error state resulting from the missing Slurm controller and then wait to see if contact is established in the meantime.

The changes include updating the `MockSlurm` code to be able to mimick the controller error, and updating the `SlurmRunner` to be able to handle the error when running `sbatch` and then attempting to check the status of queued and running jobs. As part of these changes it also implements a new `SlurmException` class which is used to identify issues with the controller.